### PR TITLE
Updated: data

### DIFF
--- a/json/bangumi-1310.json
+++ b/json/bangumi-1310.json
@@ -84,7 +84,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrifq03u.html",
-      "http://www.bilibili.com/sp/王者天下",
+      "http://www.bilibili.com/bangumi/i/583/",
       "http://www.acfun.tv/a/aa112"
     ],
     "newBgm": false,
@@ -120,7 +120,7 @@
       "http://www.youku.com/show_page/id_z3dfc462efe6911e2a705.html",
       "http://www.tudou.com/albumcover/y7w-zWgB64Q.html",
       "http://www.letv.com/comic/93453.html",
-      "http://www.bilibili.com/sp/苍蓝钢铁的琶音",
+      "http://www.bilibili.com/bangumi/i/483/",
       "http://www.acfun.tv/a/aa75"
     ],
     "newBgm": true,
@@ -171,7 +171,7 @@
     "timeCN": "0110",
     "onAirSite": [
       "http://comic.letv.com/zt/KLK/index.shtml",
-      "http://www.bilibili.com/sp/斩服少女",
+      "http://www.bilibili.com/bangumi/i/419/",
       "http://www.acfun.tv/a/aa98"
     ],
     "newBgm": true,
@@ -293,7 +293,7 @@
     "timeCN": "2100",
     "onAirSite": [
       "http://v.qq.com/cover/o/ox39rizb1w9cbv1.html",
-      "http://www.bilibili.com/sp/核爆默示录",
+      "http://www.bilibili.com/bangumi/i/485/",
       "http://www.acfun.tv/a/aa94"
     ],
     "newBgm": true,
@@ -346,7 +346,7 @@
     "timeCN": "0230",
     "onAirSite": [
       "http://v.qq.com/detail/r/rur1k9y16jaqici.html",
-      "http://www.bilibili.com/sp/金色时光",
+      "http://www.bilibili.com/bangumi/i/468/",
       "http://www.acfun.tv/a/aa101"
     ],
     "newBgm": true,
@@ -363,7 +363,7 @@
     "timeCN": "0130",
     "onAirSite": [
       "http://comic.letv.com/zt/noucome/index.shtml",
-      "http://www.bilibili.com/sp/我的脑内恋碍选项",
+      "http://www.bilibili.com/bangumi/i/2673/",
       "http://www.acfun.tv/a/aa96"
     ],
     "newBgm": true,
@@ -499,7 +499,6 @@
       "http://tv.sohu.com/s2013/jjdbf/",
       "http://www.youku.com/show_page/id_z28326c66ff2b11e28b3f.html",
       "http://www.tudou.com/albumcover/wIyiW3WYybE.html",
-      "http://www.bilibili.com/sp/境界的彼方",
       "http://www.acfun.tv/a/aa78"
     ],
     "newBgm": true,
@@ -518,7 +517,7 @@
       "http://www.tudou.com/albumcover/XhGkrzdXGf8.html",
       "http://www.youku.com/show_page/id_ze9c14c84e22611e29748.html",
       "http://v.qq.com/detail/j/jye92pufaaq3fvr.html",
-      "http://www.bilibili.com/sp/夜樱四重奏",
+      "http://www.bilibili.com/bangumi/i/473/",
       "http://www.acfun.tv/a/aa72"
     ],
     "newBgm": true,
@@ -539,7 +538,7 @@
       "http://www.tudou.com/albumcover/_nJJMEa6O6I.html",
       "http://www.iqiyi.com/a_19rrgjann1.html",
       "http://www.letv.com/comic/93033.html",
-      "http://www.bilibili.com/sp/黑子的篮球",
+      "http://www.bilibili.com/bangumi/i/1625/",
       "http://www.acfun.tv/a/aa105"
     ],
     "newBgm": true,
@@ -573,7 +572,7 @@
     "timeCN": "1605",
     "onAirSite": [
       "http://comic.letv.com/zt/magi2/index.shtml",
-      "http://www.bilibili.com/sp/魔笛MAGI",
+      "http://www.bilibili.com/bangumi/i/471/",
       "http://www.acfun.tv/a/aa107"
     ],
     "newBgm": true,
@@ -591,7 +590,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_z752c3b22741311e19498.html",
       "http://www.tudou.com/albumcover/wI4c9RXY_uE.html",
-      "http://www.bilibili.com/sp/宇宙兄弟",
+      "http://www.bilibili.com/bangumi/i/1657/",
       "http://www.acfun.tv/a/aa130"
     ],
     "newBgm": false,
@@ -608,11 +607,13 @@
     "timeCN": "",
     "onAirSite": [
       "http://tv.sohu.com/s2012/hunter/",
-      "http://www.bilibili.com/sp/全职猎人",
+      "http://www.tudou.com/albumcover/0ODgNga8X6Y.html",
+      "http://www.youku.com/show_page/id_zeb39ea8661ad11e0bea1.html",
+      "http://www.bilibili.com/sp/全职猎人#S-650",
       "http://www.acfun.tv/a/aa129"
     ],
     "newBgm": false,
-    "bgmId": 10356,
+    "bgmId": 21032,
     "showDate": "2011-10-03"
   },
   "1310_35": {
@@ -697,7 +698,7 @@
     "timeCN": "0025",
     "onAirSite": [
       "http://comic.letv.com/zt/wsflmg/index.shtml",
-      "http://www.bilibili.com/sp/武士弗拉明戈",
+      "http://www.bilibili.com/bangumi/i/476/",
       "http://www.acfun.tv/a/aa100"
     ],
     "newBgm": true,
@@ -714,7 +715,7 @@
     "timeCN": "0050",
     "onAirSite": [
       "http://comic.letv.com/zt/jllsn/index.shtml",
-      "http://www.bilibili.com/sp/伽利略少女",
+      "http://www.bilibili.com/bangumi/i/475/",
       "http://www.acfun.tv/a/aa99"
     ],
     "newBgm": true,
@@ -734,7 +735,7 @@
       "http://www.youku.com/show_page/id_z0d218d7619ca11e38b3f.html",
       "http://v.qq.com/detail/u/u0ae6bix0kt4lag.html",
       "http://www.letv.com/comic/93552.html",
-      "http://www.bilibili.com/sp/PHI·BRAIN%20神之谜题",
+      "http://www.bilibili.com/bangumi/i/489/",
       "http://www.acfun.tv/a/aa74"
     ],
     "newBgm": true,
@@ -752,7 +753,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0xgd.html",
       "http://www.youku.com/show_page/id_zb9229c08e3cb11e29748.html",
-      "http://www.bilibili.com/sp/记录的地平线",
+      "http://www.bilibili.com/bangumi/i/289/",
       "http://www.acfun.tv/a/aa70"
     ],
     "newBgm": true,
@@ -771,7 +772,7 @@
       "http://www.youku.com/show_page/id_z8fd33520055d11e3a705.html",
       "http://www.tudou.com/albumcover/mE4mtF0Jtxk.html",
       "http://v.qq.com/detail/n/nvaj06cswye3rv0.html",
-      "http://www.bilibili.com/sp/声优战队VOICESTORM7",
+      "http://www.bilibili.com/bangumi/i/460/",
       "http://www.acfun.tv/a/aa61"
     ],
     "newBgm": true,
@@ -805,7 +806,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_zd8ac33ca711211e3b8b7.html",
       "http://www.tudou.com/albumcover/IEeRScWf3H8.html",
-      "http://www.bilibili.com/sp/摸索吧！部活剧",
+      "http://www.bilibili.com/bangumi/i/1578/",
       "http://www.acfun.tv/a/aa63"
     ],
     "newBgm": true,
@@ -917,7 +918,7 @@
     "timeCN": "2330",
     "onAirSite": [
       "http://comic.letv.com/zt/snqswy/index.shtml",
-      "http://www.bilibili.com/sp/少女骑士物语",
+      "http://www.bilibili.com/bangumi/i/480/",
       "http://www.acfun.tv/a/aa106"
     ],
     "newBgm": true,
@@ -953,7 +954,7 @@
       "http://www.letv.com/comic/91812.html",
       "http://www.youku.com/show_page/id_z3e50f242de5111e2b356.html",
       "http://www.tudou.com/albumcover/GJnth25qxqo.html",
-      "http://www.bilibili.com/sp/黏黏糊糊！！角质君"
+      "http://www.bilibili.com/bangumi/i/1571/"
     ],
     "newBgm": false,
     "bgmId": 77551,
@@ -971,7 +972,7 @@
       "http://data.movie.kankan.com/movie/74027",
       "http://www.youku.com/show_page/id_z0995377e0da211e1a046.html",
       "http://www.tudou.com/albumcover/I8kEXNTYFeA.html",
-      "http://www.bilibili.com/sp/我要成为世界最强偶像",
+      "http://www.bilibili.com/bangumi/i/486/",
       "http://www.acfun.tv/a/aa73"
     ],
     "newBgm": true,
@@ -988,7 +989,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.letv.com/comic/93675.html",
-      "http://www.bilibili.com/sp/网球并不可笑嘛",
+      "http://www.bilibili.com/bangumi/i/19/",
       "http://www.acfun.tv/a/aa110"
     ],
     "newBgm": true,
@@ -1007,7 +1008,7 @@
       "http://v.qq.com/detail/s/sil8p038h3hthpd.html",
       "http://www.tudou.com/albumcover/27kPM1IBmTA.html",
       "http://www.youku.com/show_page/id_z8ef6f2500a2011e38b3f.html",
-      "http://www.bilibili.com/sp/限制级杀手",
+      "http://www.bilibili.com/bangumi/i/495/",
       "http://www.acfun.tv/a/aa62"
     ],
     "newBgm": true,
@@ -1023,8 +1024,8 @@
     "timeJP": "0030",
     "timeCN": "2330",
     "onAirSite": [
-      "http://v.qq.com/cover/p/p5yfnziow4uwunf.html",
-      "http://www.bilibili.com/sp/DIABOLIK%20LOVERS",
+      "http://v.qq.com/detail/p/p5yfnziow4uwunf.html",
+      "http://www.bilibili.com/bangumi/i/479/",
       "http://www.acfun.tv/a/aa93"
     ],
     "newBgm": false,

--- a/json/bangumi-1401.json
+++ b/json/bangumi-1401.json
@@ -84,7 +84,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrifq03u.html",
-      "http://www.bilibili.com/sp/王者天下",
+      "http://www.bilibili.com/bangumi/i/583/",
       "http://www.acfun.tv/a/aa112"
     ],
     "newBgm": false,
@@ -101,7 +101,7 @@
     "timeCN": "2105",
     "onAirSite": [
       "http://comic.letv.com/zt/liange/index.shtml",
-      "http://www.bilibili.com/sp/献给某飞行员的恋歌",
+      "http://www.bilibili.com/bangumi/i/233/",
       "http://www.acfun.tv/a/aa192"
     ],
     "newBgm": true,
@@ -135,7 +135,7 @@
     "timeCN": "0110",
     "onAirSite": [
       "http://comic.letv.com/zt/KLK/index.shtml",
-      "http://www.bilibili.com/sp/斩服少女",
+      "http://www.bilibili.com/bangumi/i/419/",
       "http://www.acfun.tv/a/aa98"
     ],
     "newBgm": false,
@@ -335,7 +335,7 @@
     "timeCN": "2235",
     "onAirSite": [
       "http://comic.letv.com/zt/weilian/index.shtml",
-      "http://www.bilibili.com/sp/伪恋",
+      "http://www.bilibili.com/bangumi/i/1573/",
       "http://www.acfun.tv/a/aa221"
     ],
     "newBgm": true,
@@ -352,7 +352,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://v.qq.com/detail/r/rur1k9y16jaqici.html",
-      "http://www.bilibili.com/sp/金色时光",
+      "http://www.bilibili.com/bangumi/i/468/",
       "http://www.acfun.tv/a/aa101"
     ],
     "newBgm": false,
@@ -386,7 +386,6 @@
     "timeCN": "0100",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgje85d.html",
-      "http://www.bilibili.com/sp/妄想学生会",
       "http://www.acfun.tv/a/aa182"
     ],
     "newBgm": true,
@@ -403,7 +402,7 @@
     "timeCN": "0130",
     "onAirSite": [
       "http://comic.letv.com/zt/huxian/index.shtml",
-      "http://www.bilibili.com/sp/稻荷恋之歌",
+      "http://www.bilibili.com/bangumi/i/257/",
       "http://www.acfun.tv/a/aa226"
     ],
     "newBgm": true,
@@ -438,7 +437,7 @@
     "onAirSite": [
       "http://comic.letv.com/zt/sjzf/index.shtml",
       "http://tv.sohu.com/s2013/sjzf/",
-      "http://www.bilibili.com/sp/世界征服～谋略之星～",
+      "http://www.bilibili.com/bangumi/i/1647/",
       "http://www.acfun.tv/a/aa222"
     ],
     "newBgm": true,
@@ -455,7 +454,7 @@
     "timeCN": "0035",
     "onAirSite": [
       "http://v.qq.com/detail/d/dob058ixul6vbw4.html",
-      "http://www.bilibili.com/sp/信长之枪",
+      "http://www.bilibili.com/bangumi/i/223/",
       "http://www.acfun.tv/a/aa188"
     ],
     "newBgm": true,
@@ -492,7 +491,7 @@
       "http://www.iqiyi.com/a_19rrgje7o1.html",
       "http://data.movie.kankan.com/movie/75159",
       "http://tv.sohu.com/s2014/buddycomplex/",
-      "http://www.bilibili.com/sp/BUDDY%20COMPLEX",
+      "http://www.bilibili.com/bangumi/i/1722/",
       "http://www.acfun.tv/a/aa199"
     ],
     "newBgm": true,
@@ -564,7 +563,7 @@
     "timeCN": "0000",
     "onAirSite": [
       "http://v.qq.com/detail/8/8afffvyby5ga318.html",
-      "http://www.bilibili.com/sp/超级索尼子",
+      "http://www.bilibili.com/bangumi/i/232/",
       "http://www.acfun.tv/a/aa193"
     ],
     "newBgm": true,
@@ -583,7 +582,7 @@
       "http://v.qq.com/detail/s/sscgn2qjxk1fc2i.html",
       "http://www.tudou.com/albumcover/0HLSH-kZAxA.html",
       "http://www.youku.com/show_page/id_z717eef92031411e38b3f.html",
-      "http://www.bilibili.com/sp/农林",
+      "http://www.bilibili.com/bangumi/i/249/",
       "http://www.acfun.tv/a/aa217"
     ],
     "newBgm": true,
@@ -623,7 +622,7 @@
       "http://www.tudou.com/albumcover/_nJJMEa6O6I.html",
       "http://www.iqiyi.com/a_19rrgjann1.html",
       "http://www.letv.com/comic/93033.html",
-      "http://www.bilibili.com/sp/黑子的篮球",
+      "http://www.bilibili.com/bangumi/i/1625/",
       "http://www.acfun.tv/a/aa105"
     ],
     "newBgm": false,
@@ -641,7 +640,7 @@
     "onAirSite": [
       "http://www.pptv.com/page/279383.html",
       "http://www.youku.com/show_page/id_z2aa61d0a235511e3b8b7.html",
-      "http://www.bilibili.com/sp/未确认进行式",
+      "http://www.bilibili.com/bangumi/i/242/",
       "http://www.acfun.tv/a/aa206"
     ],
     "newBgm": true,
@@ -675,7 +674,7 @@
     "timeCN": "1605",
     "onAirSite": [
       "http://comic.letv.com/zt/magi2/index.shtml",
-      "http://www.bilibili.com/sp/魔笛MAGI",
+      "http://www.bilibili.com/sp/魔笛MAGI#S-539",
       "http://www.acfun.tv/a/aa107"
     ],
     "newBgm": false,
@@ -695,7 +694,7 @@
       "http://www.youku.com/show_page/id_zdb819ff85bc911e38b3f.html",
       "http://v.qq.com/detail/7/75ly4e6byzt3jdk.html",
       "http://www.acfun.tv/a/aa212",
-      "http://www.bilibili.com/sp/STRANGE%2B"
+      "http://www.bilibili.com/bangumi/i/24/"
     ],
     "newBgm": true,
     "bgmId": 86804,
@@ -712,7 +711,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_z752c3b22741311e19498.html",
       "http://www.tudou.com/albumcover/wI4c9RXY_uE.html",
-      "http://www.bilibili.com/sp/宇宙兄弟",
+      "http://www.bilibili.com/bangumi/i/1657/",
       "http://www.acfun.tv/a/aa130"
     ],
     "newBgm": false,
@@ -729,11 +728,13 @@
     "timeCN": "",
     "onAirSite": [
       "http://tv.sohu.com/s2012/hunter/",
+      "http://www.tudou.com/albumcover/0ODgNga8X6Y.html",
+      "http://www.youku.com/show_page/id_zeb39ea8661ad11e0bea1.html",
       "http://www.bilibili.com/sp/全职猎人",
       "http://www.acfun.tv/a/aa129"
     ],
     "newBgm": false,
-    "bgmId": 10356,
+    "bgmId": 21032,
     "showDate": "2011-10-03"
   },
   "1401_41": {
@@ -889,7 +890,7 @@
     "timeCN": "2355",
     "onAirSite": [
       "http://comic.letv.com/zt/ginsaji/index.shtml",
-      "http://www.bilibili.com/sp/银之匙%20SILVER%20SPOON",
+      "http://www.bilibili.com/bangumi/i/240/",
       "http://www.acfun.tv/a/aa207"
     ],
     "newBgm": true,
@@ -906,7 +907,7 @@
     "timeCN": "0025",
     "onAirSite": [
       "http://comic.letv.com/zt/wsflmg/index.shtml",
-      "http://www.bilibili.com/sp/武士弗拉明戈",
+      "http://www.bilibili.com/bangumi/i/476/",
       "http://www.acfun.tv/a/aa100"
     ],
     "newBgm": false,
@@ -944,7 +945,7 @@
       "http://www.youku.com/show_page/id_z0d218d7619ca11e38b3f.html",
       "http://v.qq.com/detail/u/u0ae6bix0kt4lag.html",
       "http://www.letv.com/comic/93552.html",
-      "http://www.bilibili.com/sp/PHI·BRAIN%20神之谜题",
+      "http://www.bilibili.com/bangumi/i/489/",
       "http://www.acfun.tv/a/aa74"
     ],
     "newBgm": false,
@@ -962,7 +963,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0xgd.html",
       "http://www.youku.com/show_page/id_zb9229c08e3cb11e29748.html",
-      "http://www.bilibili.com/sp/记录的地平线",
+      "http://www.bilibili.com/bangumi/i/289/",
       "http://www.acfun.tv/a/aa70"
     ],
     "newBgm": false,
@@ -978,7 +979,7 @@
     "timeJP": "0035",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/第一神拳",
+      "http://www.bilibili.com/bangumi/i/502/",
       "http://www.acfun.tv/a/aa68"
     ],
     "newBgm": false,
@@ -1009,7 +1010,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_zd8ac33ca711211e3b8b7.html",
       "http://www.tudou.com/albumcover/IEeRScWf3H8.html",
-      "http://www.bilibili.com/sp/摸索吧！部活剧",
+      "http://www.bilibili.com/bangumi/i/1579/",
       "http://www.acfun.tv/a/aa223"
     ],
     "newBgm": true,
@@ -1098,9 +1099,7 @@
     "weekDayCN": 3,
     "timeJP": "0000",
     "timeCN": "",
-    "onAirSite": [
-      "http://www.bilibili.com/sp/攻壳机动队"
-    ],
+    "onAirSite": [],
     "newBgm": true,
     "bgmId": 92423,
     "showDate": "2014-01-07"
@@ -1117,7 +1116,7 @@
       "http://www.tudou.com/albumcover/7gCdfLVzEac.html",
       "http://www.youku.com/show_page/id_z4d14916662e111e3b8b7.html",
       "http://v.qq.com/detail/l/lek65108jsrrl4p.html",
-      "http://www.bilibili.com/sp/GO%21GO%21575",
+      "http://www.bilibili.com/bangumi/i/241/",
       "http://www.acfun.tv/a/aa210"
     ],
     "newBgm": true,
@@ -1154,7 +1153,7 @@
       "http://www.tudou.com/albumcover/VyjqLWiyiSU.html",
       "http://v.qq.com/detail/d/do9n7u9ssryk2t4.html",
       "http://www.letv.com/comic/95331.html",
-      "http://www.bilibili.com/sp/大家集合起来！FALCOM学园",
+      "http://www.bilibili.com/bangumi/i/1489/",
       "http://www.acfun.tv/a/aa187"
     ],
     "newBgm": true,
@@ -1172,7 +1171,7 @@
       "http://www.youku.com/show_page/id_z02dba6f41c3f11e3a705.html",
       "http://www.tudou.com/albumcover/YK2bP-HVmSE.html",
       "http://v.qq.com/detail/f/fifserh0g9lpnvc.html",
-      "http://www.bilibili.com/sp/PUPA",
+      "http://www.bilibili.com/bangumi/i/247/",
       "http://www.acfun.tv/a/aa211"
     ],
     "newBgm": true,

--- a/json/bangumi-1404.json
+++ b/json/bangumi-1404.json
@@ -160,7 +160,7 @@
       "http://www.youku.com/show_page/id_z3b437b226dd211e38b3f.html",
       "http://www.tudou.com/albumcover/ypBszW6A2jk.html",
       "http://www.letv.com/comic/95301.html",
-      "http://www.bilibili.com/sp/光之美少女",
+      "http://www.bilibili.com/bangumi/i/1711/",
       "http://www.acfun.tv/a/aa254"
     ],
     "newBgm": true,
@@ -197,7 +197,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_z97785dac9c5011e38b3f.html",
       "http://www.tudou.com/albumcover/AfhZfbr4YAs.html",
-      "http://www.bilibili.com/sp/爱丝卡与罗吉的工作室%20黄昏之空的炼金术士",
+      "http://www.bilibili.com/bangumi/i/190/",
       "http://www.acfun.tv/a/aa1135"
     ],
     "newBgm": true,
@@ -214,7 +214,7 @@
     "timeCN": "0230",
     "onAirSite": [
       "http://v.qq.com/detail/g/g9bv0pqsa2sr71o.html",
-      "http://www.bilibili.com/sp/剑灵",
+      "http://www.bilibili.com/bangumi/i/111/",
       "http://www.acfun.tv/a/aa1138"
     ],
     "newBgm": true,
@@ -231,7 +231,6 @@
     "timeCN": "1230",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgi8f5p.html",
-      "http://www.bilibili.com/sp/希德尼娅的骑士",
       "http://www.acfun.tv/a/aa1111"
     ],
     "newBgm": true,
@@ -268,7 +267,7 @@
       "http://v.qq.com/detail/9/9lmz99xuczth7ry.html",
       "http://www.youku.com/show_page/id_zbea97028909811e3a705.html",
       "http://www.tudou.com/albumcover/ufo-aT912FA.html",
-      "http://www.bilibili.com/sp/我们大家的河合庄",
+      "http://www.bilibili.com/bangumi/i/113/",
       "http://www.acfun.tv/a/aa1110"
     ],
     "newBgm": true,
@@ -463,7 +462,7 @@
     "timeCN": "2235",
     "onAirSite": [
       "http://comic.letv.com/zt/weilian/index.shtml",
-      "http://www.bilibili.com/sp/伪恋",
+      "http://www.bilibili.com/sp/伪恋#S-1800",
       "http://www.acfun.tv/a/aa221"
     ],
     "newBgm": false,
@@ -479,7 +478,7 @@
     "timeJP": "2330",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/魔法科高校的劣等生",
+      "http://www.bilibili.com/bangumi/i/143/",
       "http://www.acfun.tv/a/aa1058"
     ],
     "newBgm": true,
@@ -513,7 +512,7 @@
     "timeCN": "2300",
     "onAirSite": [
       "http://v.qq.com/detail/z/zpvbrqfxv585n4l.html",
-      "http://www.bilibili.com/sp/魔法少女大战",
+      "http://www.bilibili.com/bangumi/i/183/",
       "http://www.acfun.tv/a/aa1282"
     ],
     "newBgm": true,
@@ -562,7 +561,7 @@
     "timeCN": "0135",
     "onAirSite": [
       "http://v.qq.com/detail/s/sdi5wn3om79wo2m.html",
-      "http://www.bilibili.com/sp/棺姬嘉依卡",
+      "http://www.bilibili.com/bangumi/i/187/",
       "http://www.acfun.tv/a/aa1134"
     ],
     "newBgm": true,
@@ -579,7 +578,7 @@
     "timeCN": "0205",
     "onAirSite": [
       "http://comic.letv.com/zt/fengyun/index.shtml",
-      "http://www.bilibili.com/sp/风云维新大将军",
+      "http://www.bilibili.com/bangumi/i/189/",
       "http://www.acfun.tv/a/aa1133"
     ],
     "newBgm": true,
@@ -615,7 +614,7 @@
       "http://comic.letv.com/zt/yangyan/index.shtml",
       "http://www.youku.com/show_page/id_zd4d711de711c11e3a705.html",
       "http://www.tudou.com/albumcover/DNhSIN_Z3UY.html",
-      "http://www.bilibili.com/sp/目隐都市的演绎者",
+      "http://www.bilibili.com/bangumi/i/197/",
       "http://www.acfun.tv/a/aa1342"
     ],
     "newBgm": true,
@@ -719,7 +718,7 @@
     "timeCN": "0030",
     "onAirSite": [
       "http://v.qq.com/detail/k/kg70mw6f4nhwwj8.html",
-      "http://www.bilibili.com/sp/一周的朋友。",
+      "http://www.bilibili.com/bangumi/i/173/",
       "http://www.acfun.tv/a/aa1118"
     ],
     "newBgm": true,
@@ -739,7 +738,7 @@
       "http://www.youku.com/show_page/id_za8216ff2734e11e3b8b7.html",
       "http://v.qq.com/detail/5/5ok7kcoif1avn8c.html",
       "http://www.letv.com/comic/10000909.html",
-      "http://www.bilibili.com/sp/众神的恶作剧",
+      "http://www.bilibili.com/bangumi/i/170/",
       "http://www.acfun.tv/a/aa1124"
     ],
     "newBgm": true,
@@ -791,7 +790,7 @@
     "timeCN": "0100",
     "onAirSite": [
       "http://v.qq.com/detail/o/o2fm6biw90g8tbv.html",
-      "http://www.bilibili.com/sp/请问您今天要来点兔子吗？",
+      "http://www.bilibili.com/bangumi/i/191/",
       "http://www.acfun.tv/a/aa1107"
     ],
     "newBgm": true,
@@ -912,11 +911,13 @@
     "timeCN": "0400",
     "onAirSite": [
       "http://tv.sohu.com/s2012/hunter/",
+      "http://www.tudou.com/albumcover/0ODgNga8X6Y.html",
+      "http://www.youku.com/show_page/id_zeb39ea8661ad11e0bea1.html",
       "http://www.bilibili.com/sp/全职猎人",
       "http://www.acfun.tv/a/aa129"
     ],
     "newBgm": false,
-    "bgmId": 10356,
+    "bgmId": 21032,
     "showDate": "2011-10-03"
   },
   "1404_52": {
@@ -1086,7 +1087,7 @@
       "http://www.iqiyi.com/a_19rrgi95ql.html",
       "http://tv.sohu.com/s2014/m3hg/",
       "http://www.youku.com/show_page/id_z53e64c72ae7811e3a705.html",
-      "http://www.bilibili.com/sp/M3黑色之钢",
+      "http://www.bilibili.com/bangumi/i/198/",
       "http://www.acfun.tv/a/aa1129",
       "http://www.tudou.com/albumcover/bnjoDHGXv1c.html",
       "http://data.movie.kankan.com/movie/75987"
@@ -1105,7 +1106,7 @@
     "timeCN": "0030",
     "onAirSite": [
       "http://comic.letv.com/zt/pingpong/index.shtml",
-      "http://www.bilibili.com/sp/乒乓"
+      "http://www.bilibili.com/bangumi/i/192/"
     ],
     "newBgm": true,
     "bgmId": 93739,
@@ -1139,7 +1140,7 @@
     "timeCN": "0100",
     "onAirSite": [
       "http://comic.letv.com/zt/777/index.shtml",
-      "http://www.bilibili.com/sp/龙娘七七七埋藏的宝藏",
+      "http://www.bilibili.com/bangumi/i/193/",
       "http://www.acfun.tv/a/aa1307"
     ],
     "newBgm": true,
@@ -1174,7 +1175,7 @@
     "timeCN": "0300",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgi8tcp.html",
-      "http://www.bilibili.com/sp/BABY%20STEPS%20网球优等生",
+      "http://www.bilibili.com/bangumi/i/1651/",
       "http://www.acfun.tv/a/aa1235",
       "http://www.tudou.com/albumcover/Aa0hDsuTPws.html",
       "http://www.youku.com/show_page/id_z3b9a1d22800d11e3b8b7.html",
@@ -1193,9 +1194,7 @@
     "weekDayCN": 3,
     "timeJP": "0000",
     "timeCN": "",
-    "onAirSite": [
-      "http://www.bilibili.com/sp/攻壳机动队"
-    ],
+    "onAirSite": [],
     "newBgm": false,
     "bgmId": 92423,
     "showDate": "2014-01-07"
@@ -1229,7 +1228,7 @@
       "http://v.qq.com/detail/j/jscsr92k16z03ta.html",
       "http://www.tudou.com/albumcover/yxL8H61FFdc.html",
       "http://www.youku.com/show_page/id_z88a13c1aa51311e3a705.html",
-      "http://www.bilibili.com/sp/犬神同学和猫山同学",
+      "http://www.bilibili.com/bangumi/i/110/",
       "http://www.acfun.tv/a/aa1108"
     ],
     "newBgm": true,
@@ -1247,7 +1246,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/2yXUwWBdBe0.html",
       "http://www.youku.com/show_page/id_z0e6da6b4ae5411e3a705.html",
-      "http://www.bilibili.com/sp/迷你偶像",
+      "http://www.bilibili.com/bangumi/i/107/",
       "http://www.acfun.tv/a/aa1106"
     ],
     "newBgm": true,

--- a/json/bangumi-1407.json
+++ b/json/bangumi-1407.json
@@ -122,7 +122,7 @@
       "http://www.youku.com/show_page/id_zf48c67d0d8ec11e3a705.html",
       "http://www.iqiyi.com/a_19rrgif78l.html",
       "http://www.pptv.com/page/292059.html",
-      "http://www.bilibili.com/sp/战国BASARA#S-1002",
+      "http://www.bilibili.com/bangumi/i/1592/",
       "http://www.acfun.tv/a/aa2663",
       "http://tv.sohu.com/s2014/basara3/",
       "http://www.tudou.com/albumcover/YiWcAL0mKck.html"
@@ -441,7 +441,7 @@
     "timeJP": "2330",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/魔法科高校的劣等生",
+      "http://www.bilibili.com/bangumi/i/143/",
       "http://www.acfun.tv/a/aa1058"
     ],
     "newBgm": false,
@@ -475,7 +475,7 @@
     "timeCN": "2300",
     "onAirSite": [
       "http://v.qq.com/detail/z/zpvbrqfxv585n4l.html",
-      "http://www.bilibili.com/sp/魔法少女大战",
+      "http://www.bilibili.com/bangumi/i/183/",
       "http://www.acfun.tv/a/aa1282"
     ],
     "newBgm": false,
@@ -525,7 +525,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgif0st.html",
       "http://www.acfun.tv/a/aa2480",
-      "http://www.bilibili.com/sp/魔法少女☆伊莉雅"
+      "http://www.bilibili.com/bangumi/i/2574/"
     ],
     "newBgm": true,
     "bgmId": 83402,
@@ -612,7 +612,7 @@
       "http://www.youku.com/show_page/id_z66bd9cbaf6ad11e3b8b7.html",
       "http://www.tudou.com/albumcover/q1Qiog3posQ.html",
       "http://www.acfun.tv/a/aa2675",
-      "http://www.bilibili.com/sp/人生"
+      "http://www.bilibili.com/bangumi/i/48/"
     ],
     "newBgm": true,
     "bgmId": 92430,
@@ -697,7 +697,7 @@
     "timeCN": "0000",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgiff91.html",
-      "http://www.bilibili.com/sp/幕末ROCK",
+      "http://www.bilibili.com/bangumi/i/9/",
       "http://www.acfun.tv/a/aa2647",
       "http://www.letv.com/comic/10002832.html",
       "http://www.youku.com/show_page/id_za737b9a0df2a11e38b3f.html",
@@ -771,7 +771,7 @@
     "timeCN": "0305",
     "onAirSite": [
       "http://www.letv.com/comic/10002705.html",
-      "http://www.bilibili.com/sp/青春之旅"
+      "http://www.bilibili.com/bangumi/i/59/"
     ],
     "newBgm": true,
     "bgmId": 92836,
@@ -788,7 +788,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgif6md.html",
       "http://tv.sohu.com/s2014/zchzt/",
-      "http://www.bilibili.com/sp/斩·赤红之瞳！",
+      "http://www.bilibili.com/bangumi/i/52/",
       "http://www.acfun.tv/a/aa2667",
       "http://www.youku.com/show_page/id_ze2cbdefaa75911e38b3f.html",
       "http://www.tudou.com/albumcover/NBDgX_W2aJk.html"
@@ -917,7 +917,7 @@
       "http://www.tudou.com/albumcover/kP9MBFbhLH4.html",
       "http://www.youku.com/show_page/id_zfb9af3d4cdc011e3b8b7.html",
       "http://www.acfun.tv/a/aa2654",
-      "http://www.bilibili.com/sp/STRANGE+#S-1022"
+      "http://www.bilibili.com/bangumi/i/25/"
     ],
     "newBgm": true,
     "bgmId": 100986,
@@ -950,11 +950,13 @@
     "timeCN": "0400",
     "onAirSite": [
       "http://tv.sohu.com/s2012/hunter/",
+      "http://www.tudou.com/albumcover/0ODgNga8X6Y.html",
+      "http://www.youku.com/show_page/id_zeb39ea8661ad11e0bea1.html",
       "http://www.bilibili.com/sp/全职猎人",
       "http://www.acfun.tv/a/aa129"
     ],
     "newBgm": false,
-    "bgmId": 10356,
+    "bgmId": 21032,
     "showDate": "2011-10-03"
   },
   "1407_54": {
@@ -1016,7 +1018,7 @@
       "http://www.youku.com/show_page/id_zdde1b9beb26211e3b8b7.html",
       "http://www.letv.com/comic/10002971.html",
       "http://www.acfun.tv/a/aa2670",
-      "http://www.bilibili.com/sp/月刊少女野崎君",
+      "http://www.bilibili.com/bangumi/i/53/",
       "http://www.iqiyi.com/a_19rrgif6ex.html",
       "http://tv.sohu.com/s2014/yksnyqtx/",
       "http://www.tudou.com/albumcover/0BK5sqbKQm4.html"
@@ -1071,7 +1073,7 @@
       "http://www.iqiyi.com/a_19rrgi95ql.html",
       "http://tv.sohu.com/s2014/m3hg/",
       "http://www.youku.com/show_page/id_z53e64c72ae7811e3a705.html",
-      "http://www.bilibili.com/sp/M3黑色之钢",
+      "http://www.bilibili.com/bangumi/i/198/",
       "http://www.acfun.tv/a/aa1129",
       "http://www.tudou.com/albumcover/bnjoDHGXv1c.html",
       "http://data.movie.kankan.com/movie/75987"
@@ -1159,7 +1161,7 @@
     "timeCN": "0300",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgi8tcp.html",
-      "http://www.bilibili.com/sp/BABY%20STEPS%20网球优等生",
+      "http://www.bilibili.com/bangumi/i/1651/",
       "http://www.acfun.tv/a/aa1235",
       "http://www.tudou.com/albumcover/Aa0hDsuTPws.html",
       "http://www.youku.com/show_page/id_z3b9a1d22800d11e3b8b7.html",
@@ -1214,7 +1216,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_zbe6a268cb7e111e3a705.html",
       "http://www.letv.com/comic/10002982.html",
-      "http://www.bilibili.com/sp/DRAMATICAL%20MURDER",
+      "http://www.bilibili.com/bangumi/i/55/",
       "http://www.acfun.tv/a/aa2671",
       "http://www.iqiyi.com/a_19rrgif6qp.html",
       "http://tv.sohu.com/s2014/dramaticalmurder/",
@@ -1284,7 +1286,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/SQfmIXvvt6Y.html",
       "http://www.youku.com/show_page/id_z4f083bbebec411e3b8b7.html",
-      "http://www.bilibili.com/sp/漫研部",
+      "http://www.bilibili.com/bangumi/i/8/",
       "http://www.acfun.tv/a/aa2687"
     ],
     "newBgm": true,
@@ -1341,7 +1343,7 @@
       "http://www.youku.com/show_page/id_z3b437b226dd211e38b3f.html",
       "http://www.tudou.com/albumcover/ypBszW6A2jk.html",
       "http://www.letv.com/comic/95301.html",
-      "http://www.bilibili.com/sp/光之美少女",
+      "http://www.bilibili.com/bangumi/i/1711/",
       "http://www.acfun.tv/a/aa254"
     ],
     "newBgm": false,
@@ -1357,7 +1359,7 @@
     "timeJP": "2127",
     "timeCN": "2230",
     "onAirSite": [
-      "http://www.bilibili.com/sp/抓狂一族",
+      "http://www.bilibili.com/bangumi/i/92/",
       "http://www.tudou.com/albumcover/hTkDFExYxJc.html",
       "http://www.youku.com/show_page/id_zd521ead8018b11e4a705.html"
     ],
@@ -1410,7 +1412,7 @@
     "timeJP": "2310",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/荷包蛋的蛋黄什么时候戳破才好？",
+      "http://www.bilibili.com/bangumi/i/84/",
       "http://www.tudou.com/albumcover/QeF47CAU9jM.html",
       "http://www.youku.com/show_page/id_za9b52a10241b11e4a705.html",
       "http://www.letv.com/comic/10004046.html"

--- a/json/bangumi-1410.json
+++ b/json/bangumi-1410.json
@@ -103,7 +103,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_za5f390803ed111e4b2ad.html",
       "http://www.tudou.com/albumcover/V6JR5hlW_vs.html",
-      "http://www.bilibili.com/sp/世嘉硬件女孩"
+      "http://www.bilibili.com/bangumi/i/321/"
     ],
     "newBgm": true,
     "bgmId": 101784,
@@ -118,7 +118,7 @@
     "timeJP": "1800",
     "timeCN": "2148",
     "onAirSite": [
-      "http://www.bilibili.com/sp/绿林女儿罗妮娅",
+      "http://www.bilibili.com/bangumi/i/328/",
       "http://www.tudou.com/albumcover/jPC-noZzwUA.html",
       "http://www.youku.com/show_page/id_z730c84360fee11e48b3f.html",
       "http://www.acfun.tv/a/aa1464843"
@@ -175,7 +175,7 @@
       "http://www.pptv.com/page/296388.html",
       "http://www.youku.com/show_page/id_z8c74cc8ace7611e3a705.html",
       "http://www.tudou.com/albumcover/7CNapiWZqVk.html",
-      "http://www.bilibili.com/sp/甘城光辉游乐园",
+      "http://www.bilibili.com/bangumi/i/281/",
       "http://www.acfun.tv/a/aa1464810"
     ],
     "newBgm": true,
@@ -211,7 +211,7 @@
     "onAirSite": [
       "http://www.letv.com/comic/10005167.html",
       "http://www.iqiyi.com/a_19rrhbzehh.html",
-      "http://www.bilibili.com/sp/我，要成为双马尾%E3%80%82",
+      "http://www.bilibili.com/bangumi/i/324/",
       "http://www.acfun.tv/a/aa1464824"
     ],
     "newBgm": true,
@@ -278,7 +278,7 @@
     "timeJP": "2254",
     "timeCN": "2301",
     "onAirSite": [
-      "http://www.bilibili.com/sp/我家浴缸的二三事",
+      "http://www.bilibili.com/bangumi/i/311/",
       "http://www.iqiyi.com/a_19rrhc0z1p.html",
       "http://v.qq.com/detail/v/vkvksohhix5upx7.html",
       "http://www.youku.com/show_page/id_z49e9085a3d6a11e4b522.html",
@@ -317,7 +317,7 @@
     "timeJP": "2130",
     "timeCN": "2230",
     "onAirSite": [
-      "http://www.bilibili.com/sp/天体的秩序",
+      "http://www.bilibili.com/bangumi/i/296/",
       "http://www.tudou.com/albumcover/k8qIX3LeVBw.html",
       "http://www.youku.com/show_page/id_z7f0ea2e2bd4511e3a705.html",
       "http://www.acfun.tv/a/aa1464809"
@@ -335,7 +335,7 @@
     "timeJP": "2130",
     "timeCN": "2330",
     "onAirSite": [
-      "http://www.bilibili.com/sp/电器街的漫画店",
+      "http://www.bilibili.com/bangumi/i/282/",
       "http://www.youku.com/show_page/id_ze4002ea421d211e4a705.html",
       "http://www.tudou.com/albumcover/t_PmumgmCd0.html",
       "http://www.acfun.tv/a/aa1464849"
@@ -371,7 +371,7 @@
     "timeCN": "0135",
     "onAirSite": [
       "http://v.qq.com/detail/c/crrtngniol48xnn.html",
-      "http://www.bilibili.com/sp/棺姬嘉依卡#S-1334",
+      "http://www.bilibili.com/bangumi/i/188/",
       "http://www.acfun.tv/a/aa1464827"
     ],
     "newBgm": true,
@@ -392,7 +392,7 @@
       "http://v.qq.com/detail/5/54v59r074ncc1kq.html",
       "http://www.youku.com/show_page/id_z46465a1c711f11e38b3f.html",
       "http://www.letv.com/comic/10005152.html",
-      "http://www.bilibili.com/sp/FATE%2FSTAY%20NIGHT%20-UBW-",
+      "http://www.bilibili.com/bangumi/i/1586/",
       "http://www.acfun.tv/a/aa1464802"
     ],
     "newBgm": true,
@@ -482,7 +482,7 @@
     "timeCN": "2230",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0xbh.html",
-      "http://www.bilibili.com/sp/魔弹之王与战姬",
+      "http://www.bilibili.com/bangumi/i/291/",
       "http://www.acfun.tv/a/aa1464820",
       "http://www.pptv.com/page/268775.html",
       "http://www.youku.com/show_page/id_z17369f303d6511e4b2ad.html",
@@ -520,7 +520,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/3sgyRBy1t1M.html",
       "http://www.youku.com/show_page/id_zd6c247ae3d6b11e4a080.html",
-      "http://www.bilibili.com/sp/晨曦公主",
+      "http://www.bilibili.com/bangumi/i/318/",
       "http://www.iqiyi.com/a_19rrhc0ytd.html",
       "http://www.pptv.com/page/296315.html",
       "http://www.acfun.tv/v/ab1464837"
@@ -670,7 +670,7 @@
       "http://www.youku.com/show_page/id_ze31f4ef6c92211e3a705.html",
       "http://www.tudou.com/albumcover/pPuLbZdMqTY.html",
       "http://www.acfun.tv/a/aa1464821",
-      "http://www.bilibili.com/sp/银仙"
+      "http://www.bilibili.com/bangumi/i/297/"
     ],
     "newBgm": true,
     "bgmId": 100227,
@@ -719,7 +719,7 @@
     "timeJP": "1630",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/记录的地平线#S-1327",
+      "http://www.bilibili.com/bangumi/i/290/",
       "http://www.pptv.com/page/297514.html",
       "http://www.iqiyi.com/a_19rrhc10bp.html",
       "http://www.youku.com/show_page/id_z78f9354e3d6411e4a080.html",
@@ -741,7 +741,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/vVolwaPqgHI.html",
       "http://www.youku.com/show_page/id_z75eea0d2b24a11e38b3f.html",
-      "http://www.bilibili.com/sp/四月是你的谎言",
+      "http://www.bilibili.com/bangumi/i/1699/",
       "http://www.iqiyi.com/a_19rrhbzeu5.html",
       "http://www.acfun.tv/v/ab1464808"
     ],
@@ -760,7 +760,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/fPpEVMRCTFc.html",
       "http://www.youku.com/show_page/id_z5d9421503e5011e4b2ad.html",
-      "http://www.bilibili.com/sp/临时女友",
+      "http://www.bilibili.com/bangumi/i/301/",
       "http://www.letv.com/comic/10005271.html",
       "http://www.iqiyi.com/a_19rrhbz5w5.html",
       "http://www.pptv.com/page/296498.html",
@@ -779,7 +779,7 @@
     "timeJP": "0040",
     "timeCN": "0140",
     "onAirSite": [
-      "http://www.bilibili.com/sp/TRINITY%20SEVEN%20七人魔法使",
+      "http://www.bilibili.com/bangumi/i/317/",
       "http://www.acfun.tv/a/aa1464825",
       "http://www.tudou.com/albumcover/8kRmJfnSOqg.html",
       "http://www.youku.com/show_page/id_zdb2ab4f4066e11e4a705.html",
@@ -804,7 +804,7 @@
       "http://www.iqiyi.com/a_19rrhc0yyx.html",
       "http://www.pptv.com/page/295945.html",
       "http://www.letv.com/comic/10005151.html",
-      "http://www.bilibili.com/sp/日常系的异能战斗",
+      "http://www.bilibili.com/bangumi/i/313/",
       "http://www.acfun.tv/a/aa1464815"
     ],
     "newBgm": true,
@@ -820,7 +820,7 @@
     "timeJP": "1800",
     "timeCN": "1830",
     "onAirSite": [
-      "http://www.bilibili.com/sp/怪盗JOKER",
+      "http://www.bilibili.com/bangumi/i/1569/",
       "http://www.iqiyi.com/a_19rrhc0zch.html",
       "http://www.youku.com/show_page/id_z3da69dee21c911e4a705.html",
 
@@ -839,7 +839,7 @@
     "timeJP": "2330",
     "timeCN": "0030",
     "onAirSite": [
-      "http://www.bilibili.com/sp/大图书馆的牧羊人",
+      "http://www.bilibili.com/bangumi/i/323/",
       "http://www.tudou.com/albumcover/tQz-M8MDLYc.html",
       "http://www.youku.com/show_page/id_z8ea489d03d8611e4a080.html",
       "http://v.qq.com/detail/w/w9galx5d4dm0udo.html",
@@ -864,7 +864,7 @@
       "http://www.tudou.com/albumcover/CYo3K-hgmOs.html",
       "http://v.qq.com/detail/1/1b4rfk13s84xu48.html",
       "http://www.acfun.tv/a/aa1464853",
-      "http://www.bilibili.com/sp/天地无用！#S-1338"
+      "http://www.bilibili.com/bangumi/i/1617/"
     ],
     "newBgm": true,
     "bgmId": 104878,
@@ -880,7 +880,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.acfun.tv/a/aa1464852",
-      "http://www.bilibili.com/sp/关于完全听不懂老公在说什么的事",
+      "http://www.bilibili.com/bangumi/i/1530/",
       "http://www.letv.com/comic/10005221.html",
       "http://www.youku.com/show_page/id_zd3a9f5563d6d11e4b522.html",
       "http://www.tudou.com/albumcover/G4w3mr-huo0.html",
@@ -989,7 +989,7 @@
       "http://www.youku.com/show_page/id_z3b437b226dd211e38b3f.html",
       "http://www.tudou.com/albumcover/ypBszW6A2jk.html",
       "http://www.letv.com/comic/95301.html",
-      "http://www.bilibili.com/sp/光之美少女",
+      "http://www.bilibili.com/bangumi/i/1711/",
       "http://www.acfun.tv/a/aa254"
     ],
     "newBgm": false,
@@ -1192,7 +1192,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgif6md.html",
       "http://tv.sohu.com/s2014/zchzt/",
-      "http://www.bilibili.com/sp/斩·赤红之瞳！",
+      "http://www.bilibili.com/bangumi/i/52/",
       "http://www.acfun.tv/a/aa2667",
       "http://www.youku.com/show_page/id_ze2cbdefaa75911e38b3f.html",
       "http://www.tudou.com/albumcover/NBDgX_W2aJk.html"
@@ -1213,7 +1213,6 @@
       "http://www.iqiyi.com/a_19rrhc1759.html",
       "http://tv.sohu.com/s2014/buddycomplex/",
       "http://data.movie.kankan.com/movie/75159",
-      "http://www.bilibili.com/sp/BUDDY%20COMPLEX",
       "http://www.acfun.tv/a/aa1464854"
     ],
     "newBgm": true,

--- a/json/bangumi-1501.json
+++ b/json/bangumi-1501.json
@@ -139,7 +139,7 @@
     "timeJP": "1800",
     "timeCN": "2148",
     "onAirSite": [
-      "http://www.bilibili.com/sp/绿林女儿罗妮娅",
+      "http://www.bilibili.com/bangumi/i/328/",
       "http://www.tudou.com/albumcover/jPC-noZzwUA.html",
       "http://www.youku.com/show_page/id_z730c84360fee11e48b3f.html",
       "http://www.acfun.tv/a/aa1464843"
@@ -231,7 +231,7 @@
       "http://www.youku.com/show_page/id_z3b437b226dd211e38b3f.html",
       "http://www.tudou.com/albumcover/ypBszW6A2jk.html",
       "http://www.letv.com/comic/95301.html",
-      "http://www.bilibili.com/sp/光之美少女",
+      "http://www.bilibili.com/bangumi/i/1711/",
       "http://www.acfun.tv/a/aa254"
     ],
     "newBgm": false,
@@ -268,7 +268,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/3sgyRBy1t1M.html",
       "http://www.youku.com/show_page/id_zd6c247ae3d6b11e4a080.html",
-      "http://www.bilibili.com/sp/晨曦公主",
+      "http://www.bilibili.com/bangumi/i/318/",
       "http://www.iqiyi.com/a_19rrhc0ytd.html",
       "http://www.pptv.com/page/296315.html",
       "http://www.acfun.tv/v/ab1464837"
@@ -343,7 +343,7 @@
     "timeJP": "1630",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/记录的地平线#S-1327",
+      "http://www.bilibili.com/bangumi/i/290/",
       "http://www.pptv.com/page/297514.html",
       "http://www.iqiyi.com/a_19rrhc10bp.html",
       "http://www.acfun.tv/v/ab1464807"
@@ -363,7 +363,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/vVolwaPqgHI.html",
       "http://www.youku.com/show_page/id_z75eea0d2b24a11e38b3f.html",
-      "http://www.bilibili.com/sp/四月是你的谎言",
+      "http://www.bilibili.com/bangumi/i/1699/",
       "http://www.iqiyi.com/a_19rrhbzeu5.html",
       "http://www.acfun.tv/v/ab1464808"
     ],
@@ -548,7 +548,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/p_w6pxA6H0c.html",
       "http://www.youku.com/show_page/id_z891372fc3ed411e4b522.html",
-      "http://www.bilibili.com/sp/绝对双刃",
+      "http://www.bilibili.com/bangumi/i/1524/",
       "http://www.iqiyi.com/a_19rrhaxac1.html",
       "http://www.letv.com/ptv/vplay/21626588.html",
       "http://www.acfun.tv/v/ab1470155"
@@ -570,7 +570,7 @@
       "http://www.letv.com/comic/10007745.html",
       "http://www.youku.com/show_page/id_z33455b5a6dcf11e3a705.html",
       "http://www.tudou.com/albumcover/VyjqLWiyiSU.html",
-      "http://www.bilibili.com/sp/大家集合起来！FALCOM学园#S-1601",
+      "http://www.bilibili.com/bangumi/i/1490/",
       "http://www.acfun.tv/v/ab1470156"
     ],
     "newBgm": true,
@@ -635,7 +635,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/s3GSriQOpPw.html",
       "http://www.youku.com/show_page/id_z1bac0432478911e4abda.html",
-      "http://www.bilibili.com/sp/元气少女缘结神#S-1611",
+      "http://www.bilibili.com/bangumi/i/1523/",
       "http://www.iqiyi.com/a_19rrhaxakd.html",
       "http://www.letv.com/comic/10007496.html",
       "http://v.qq.com/detail/9/91ekf8i4watxc1p.html",
@@ -674,7 +674,7 @@
       "http://www.youku.com/show_page/id_z514b5a7259c511e4b432.html",
       "http://www.iqiyi.com/a_19rrhax3mh.html",
       "http://v.qq.com/detail/v/vc71qe27w79ma3c.html",
-      "http://www.bilibili.com/sp/美男高校地球防卫部LOVE！",
+      "http://www.bilibili.com/bangumi/i/1520/",
       "http://www.acfun.tv/v/ab1470137"
     ],
     "newBgm": true,
@@ -692,7 +692,7 @@
     "onAirSite": [
       "http://www.letv.com/comic/10007860.html",
       "http://www.pptv.com/page/303321.html",
-      "http://www.bilibili.com/sp/军方！",
+      "http://www.bilibili.com/bangumi/i/1515/",
       "http://www.acfun.tv/v/ab1470159"
     ],
     "newBgm": true,
@@ -744,7 +744,7 @@
     "timeCN": "1100",
     "onAirSite": [
       "http://v.qq.com/detail/x/xccr2dywql8z3oz.html",
-      "http://www.bilibili.com/sp/血型君！#S-1603",
+      "http://www.bilibili.com/bangumi/i/1519/",
       "http://www.acfun.tv/v/ab1470161"
     ],
     "newBgm": true,
@@ -760,6 +760,7 @@
     "timeJP": "2254",
     "timeCN": "",
     "onAirSite": [
+      "http://www.letv.com/comic/10007889.html",
       "http://www.pptv.com/page/308804.html",
       "http://www.acfun.tv/v/ab1470209"
     ],
@@ -801,7 +802,7 @@
       "http://www.tudou.com/albumcover/MC8VIcj1lSI.html",
       "http://www.youku.com/show_page/id_z090ec930b26611e3a705.html",
       "http://www.iqiyi.com/a_19rrhawxqd.html",
-      "http://www.bilibili.com/sp/路人女主的养成方法",
+      "http://www.bilibili.com/bangumi/i/1512/",
       "http://www.acfun.tv/v/ab1470120"
     ],
     "newBgm": true,
@@ -820,7 +821,7 @@
       "http://www.tudou.com/albumcover/mDLBXR-RtX4.html",
       "http://www.youku.com/show_page/id_zd92606e290a511e4b2ad.html",
       "http://v.qq.com/detail/d/df4xtlcgfw0ka3y.html",
-      "http://www.bilibili.com/sp/幸腹涂鸦",
+      "http://www.bilibili.com/bangumi/i/2569/",
       "http://www.iqiyi.com/a_19rrhax0m9.html",
       "http://www.acfun.tv/v/ab1470160"
     ],
@@ -838,7 +839,7 @@
     "timeCN": "0830",
     "onAirSite": [
       "http://www.pptv.com/page/303412.html?set_id=9037516",
-      "http://www.bilibili.com/sp/铳皇无尽的法夫纳",
+      "http://www.bilibili.com/bangumi/i/1511/",
       "http://www.acfun.tv/v/ab1470129"
     ],
     "newBgm": true,
@@ -877,7 +878,7 @@
       "http://www.letv.com/comic/10007495.html",
       "http://www.tudou.com/albumcover/qgdKuHlPg9g.html",
       "http://www.youku.com/show_page/id_z1e13314abec311e38b3f.html",
-      "http://www.bilibili.com/sp/偶像大师%20灰姑娘女孩",
+      "http://www.bilibili.com/bangumi/i/1509/",
       "http://www.acfun.tv/v/ab1470132"
     ],
     "newBgm": true,
@@ -969,7 +970,7 @@
       "http://www.youku.com/show_page/id_z2c9c7552acd811e38b3f.html",
       "http://v.qq.com/detail/4/4gmobofw9fltve9.html",
       "http://www.iqiyi.com/a_19rrhay53x.html",
-      "http://www.bilibili.com/sp/无头骑士异闻录#S-1596",
+      "http://www.bilibili.com/bangumi/i/1505/",
       "http://www.acfun.tv/v/ab1470124"
     ],
     "newBgm": true,
@@ -1005,7 +1006,7 @@
       "http://www.youku.com/show_page/id_zf7651dc2599c11e4b522.html",
       "http://www.iqiyi.com/a_19rrhay55h.html",
       "http://v.qq.com/detail/i/i2pfes4ebq4fapc.html",
-      "http://www.bilibili.com/sp/DOG%20DAYS#S-1606",
+      "http://www.bilibili.com/bangumi/i/1633/",
       "http://www.acfun.tv/v/ab1470122"
     ],
     "newBgm": true,
@@ -1047,7 +1048,7 @@
       "http://v.qq.com/detail/x/x9oa8s8k3v6g8xm.html",
       "http://www.pptv.com/page/303313.html",
       "http://data.movie.kankan.com/movie/87456",
-      "http://www.bilibili.com/sp/黑子的篮球#S-1597",
+      "http://www.bilibili.com/bangumi/i/1626/",
       "http://www.acfun.tv/v/ab1470145"
     ],
     "newBgm": true,
@@ -1069,7 +1070,7 @@
       "http://www.letv.com/comic/10007473.html",
       "http://v.qq.com/detail/3/3udwgbjzd6l7ruw.html",
       "http://data.movie.kankan.com/movie/87476",
-      "http://www.bilibili.com/sp/夜之小双侠",
+      "http://www.bilibili.com/bangumi/i/1492/",
       "http://www.acfun.tv/v/ab1470149"
     ],
     "newBgm": true,
@@ -1089,7 +1090,7 @@
       "http://www.youku.com/show_page/id_z8a0d8e1c59b511e4b2ad.html",
       "http://www.letv.com/comic/10007476.html",
       "http://www.iqiyi.com/a_19rrhay4hp.html",
-      "http://www.bilibili.com/sp/纯洁的玛利亚",
+      "http://www.bilibili.com/bangumi/i/1491/",
       "http://www.acfun.tv/v/ab1470130"
     ],
     "newBgm": true,
@@ -1110,7 +1111,7 @@
       "http://www.iqiyi.com/a_19rrhay4m1.html",
       "http://www.letv.com/comic/10007478.html",
       "http://v.qq.com/detail/z/zq603skcxexud1x.html",
-      "http://www.bilibili.com/sp/圣剑使的禁咒咏唱",
+      "http://www.bilibili.com/bangumi/i/1488/",
       "http://www.acfun.tv/v/ab1470134"
     ],
     "newBgm": true,
@@ -1133,7 +1134,7 @@
       "http://www.tudou.com/albumcover/f7OqHM6hee4.html",
       "http://www.youku.com/show_page/id_z8a899d3e960c11e4b2ad.html",
       "http://data.movie.kankan.com/movie/87459",
-      "http://www.bilibili.com/sp/战国无双",
+      "http://www.bilibili.com/bangumi/i/1658/",
       "http://www.acfun.tv/v/ab1470150"
     ],
     "newBgm": true,
@@ -1166,7 +1167,7 @@
     "timeCN": "0205",
     "onAirSite": [
       "http://www.letv.com/comic/10007487.html",
-      "http://www.bilibili.com/sp/ISUCA",
+      "http://www.bilibili.com/bangumi/i/1527/",
       "http://www.acfun.tv/v/ab1470136",
       "http://www.iqiyi.com/a_19rrhavmqx.html"
     ],
@@ -1211,7 +1212,7 @@
     "timeCN": "0435",
     "onAirSite": [
       "http://v.qq.com/detail/p/p9g77zamk0kvlka.html",
-      "http://www.bilibili.com/sp/动画心疗系",
+      "http://www.bilibili.com/bangumi/i/1528/",
       "http://www.acfun.tv/v/ab1470154"
     ],
     "newBgm": true,

--- a/json/bangumi-1504.json
+++ b/json/bangumi-1504.json
@@ -236,11 +236,11 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhay5rp.html",
       "http://v.qq.com/detail/w/wgzklo5zkrgalda.html",
-      "http://www.pptv.com/page/295755.html?set_id=9036881",
+      "http://www.pptv.com/page/295755.html",
       "http://www.letv.com/comic/10007495.html",
       "http://www.tudou.com/albumcover/qgdKuHlPg9g.html",
       "http://www.youku.com/show_page/id_z1e13314abec311e38b3f.html",
-      "http://www.bilibili.com/sp/偶像大师%20灰姑娘女孩",
+      "http://www.bilibili.com/bangumi/i/1509/",
       "http://www.acfun.tv/v/ab1470132"
     ],
     "newBgm": false,
@@ -263,7 +263,7 @@
       "http://v.qq.com/detail/x/x9oa8s8k3v6g8xm.html",
       "http://www.pptv.com/page/303313.html",
       "http://data.movie.kankan.com/movie/87456",
-      "http://www.bilibili.com/sp/黑子的篮球#S-1597",
+      "http://www.bilibili.com/bangumi/i/1626/",
       "http://www.acfun.tv/v/ab1470145_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=黑子的篮球%20第三季"
     ],
@@ -298,7 +298,7 @@
     "timeCN": "0435",
     "onAirSite": [
       "http://v.qq.com/detail/p/p9g77zamk0kvlka.html",
-      "http://www.bilibili.com/sp/动画心疗系",
+      "http://www.bilibili.com/bangumi/i/1528/",
       "http://www.acfun.tv/v/ab1470154_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=动画心疗系"
     ],
@@ -410,7 +410,7 @@
     "timeJP": "0000",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/关于完全听不懂老公在说什么的事#S-1798",
+      "http://www.bilibili.com/bangumi/i/1655/",
       "http://www.pptv.com/page/311518.html",
       "http://www.letv.com/comic/10008623.html",
       "http://www.youku.com/show_page/id_z95416adcd1ed11e4a080.html",
@@ -430,7 +430,7 @@
     "timeJP": "0046",
     "timeCN": "1000",
     "onAirSite": [
-      "http://www.bilibili.com/sp/我的青春恋爱物语果然有问题#S-1810",
+      "http://www.bilibili.com/bangumi/i/1540/",
       "http://www.pptv.com/page/308997.html",
       "http://www.youku.com/show_page/id_zd569d83ace9511e3a705.html",
       "http://www.tudou.com/albumcover/hdhCMzUcgYo.html",
@@ -468,7 +468,7 @@
     "timeJP": "2130",
     "timeCN": "2300",
     "onAirSite": [
-      "http://www.bilibili.com/sp/魔法少女奈叶#S-1790",
+      "http://www.bilibili.com/bangumi/i/1538/",
       "http://www.tudou.com/albumcover/J8Qhnbr20CQ.html",
       "http://www.youku.com/show_page/id_z9677b238d1f411e4b432.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=魔法少女奈叶%20ViVid"
@@ -507,7 +507,7 @@
       "http://www.youku.com/show_page/id_z3eebb5a2d1f711e4abda.html",
       "http://v.qq.com/detail/l/l2h6j510vy2r11e.html",
       "http://www.letv.com/comic/10008624.html",
-      "http://www.bilibili.com/sp/小长门有希的消失",
+      "http://www.bilibili.com/bangumi/i/1558/",
       "http://www.acfun.tv/v/ab1470229_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=小长门有希的消失"
     ],
@@ -527,7 +527,7 @@
       "http://www.tudou.com/albumcover/W7crDVrgjUU.html",
       "http://www.youku.com/show_page/id_z01bc34c0d1fe11e4a080.html",
       "http://v.qq.com/detail/z/zkzeoy0ybuydkp7.html",
-      "http://www.bilibili.com/sp/VAMPIRE%20HOLMES",
+      "http://www.bilibili.com/bangumi/i/1557/",
       "http://www.acfun.tv/v/ab1470230_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=吸血鬼福尔摩斯"
     ],
@@ -544,7 +544,7 @@
     "timeJP": "0125",
     "timeCN": "0510",
     "onAirSite": [
-      "http://www.bilibili.com/sp/食戟之灵",
+      "http://www.bilibili.com/bangumi/i/1559/",
       "http://www.iqiyi.com/a_19rrhay9y1.html",
       "http://www.letv.com/comic/10008945.html",
       "http://www.pptv.com/page/302468.html",
@@ -570,7 +570,7 @@
       "http://www.letv.com/comic/10008950.html",
       "http://www.tudou.com/albumcover/4f9dl2adFPg.html",
       "http://www.pptv.com/page/319657.html",
-      "http://www.bilibili.com/sp/宝石宠物#S-1811"
+      "http://www.bilibili.com/bangumi/i/1671/"
     ],
     "newBgm": true,
     "bgmId": 129823,
@@ -641,7 +641,7 @@
       "http://www.tudou.com/albumcover/oGlXUbsk0Hw.html",
       "http://www.youku.com/show_page/id_z7b76708ad29111e49e2a.html",
       "http://v.qq.com/detail/i/izsh50sm4ysz5j5.html",
-      "http://www.bilibili.com/sp/终结的炽天使",
+      "http://www.bilibili.com/bangumi/i/1555/",
       "http://www.letv.com/comic/10008808.html",
       "http://www.pptv.com/page/311534.html",
       "http://www.acfun.tv/v/ab1470236_0",
@@ -679,7 +679,7 @@
       "http://www.youku.com/show_page/id_z28c17ee4d20411e4b522.html",
       "http://www.letv.com/comic/10008462.html",
       "http://www.iqiyi.com/a_19rrhay9ld.html",
-      "http://www.bilibili.com/sp/Gunslinger%20Stratos",
+      "http://www.bilibili.com/bangumi/i/1554/",
       "http://www.acfun.tv/v/ab1470238_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=枪神斯托拉塔斯"
     ],
@@ -699,7 +699,7 @@
       "http://www.tudou.com/albumcover/geFp2M0qg4A.html",
       "http://www.letv.com/comic/10005152.html",
       "http://v.qq.com/detail/5/54v59r074ncc1kq.html",
-      "http://www.bilibili.com/sp/FATE/STAY%20NIGHT%20-UBW-#S-1829",
+      "http://www.bilibili.com/bangumi/i/1587/",
       "http://www.iqiyi.com/a_19rrhay91x.html",
       "http://www.youku.com/show_page/id_zdde7f9fa3d6811e4a080.html",
       "http://www.acfun.tv/v/ab1470239_0",
@@ -722,7 +722,7 @@
       "http://www.tudou.com/albumcover/1aSNea7HH_E.html",
       "http://www.youku.com/show_page/id_z15ef07b4d29011e4b522.html",
       "http://www.letv.com/comic/10008948.html",
-      "http://www.bilibili.com/sp/Plastic%20Memories",
+      "http://www.bilibili.com/bangumi/i/1552/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=可塑性记忆"
     ],
     "newBgm": true,
@@ -741,7 +741,7 @@
       "http://www.tudou.com/albumcover/XuEeF0KkEWc.html",
       "http://www.youku.com/show_page/id_zefa80170d20611e4b432.html",
       "http://v.qq.com/detail/9/9ni9yqck4tdy63j.html",
-      "http://www.bilibili.com/sp/歌之☆王子殿下%20真爱1000#S-1799",
+      "http://www.bilibili.com/bangumi/i/1563/",
       "http://www.acfun.tv/v/ab1470241_0",
       "http://www.letv.com/comic/10008836.html"
     ],
@@ -758,7 +758,7 @@
     "timeJP": "0055",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/摸索吧！部活剧#S-1812",
+      "http://www.bilibili.com/bangumi/i/1580/",
       "http://www.pptv.com/page/318878.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=摸索吧！部活剧%20第三季"
     ],
@@ -780,7 +780,7 @@
       "http://www.letv.com/comic/10008625.html",
       "http://www.pptv.com/page/309013.html",
       "http://www.iqiyi.com/a_19rrhay9bt.html",
-      "http://www.bilibili.com/sp/KEKKAI%20SENSEN",
+      "http://www.bilibili.com/bangumi/i/1553/",
       "http://www.acfun.tv/v/ab1470243_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=血界战线"
     ],
@@ -815,7 +815,7 @@
       "http://www.letv.com/comic/10008629.html",
       "http://v.qq.com/detail/2/2nqzaniq3tunys1.html",
       "http://www.pptv.com/page/305135.html",
-      "http://www.bilibili.com/sp/亚尔斯兰战记",
+      "http://www.bilibili.com/bangumi/i/1551/",
       "http://www.iqiyi.com/a_19rrhaybsx.html",
       "http://www.acfun.tv/v/ab1470244_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=亚尔斯兰战记"
@@ -853,7 +853,7 @@
     "timeJP": "2100",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/SHOW%20BY%20ROCK%21%21",
+      "http://www.bilibili.com/bangumi/i/1549/",
       "http://www.youku.com/show_page/id_zda589ea6d37811e4b432.html",
       "http://www.tudou.com/albumcover/Clug8mMZVHI.html",
       "http://www.pptv.com/page/309461.html",
@@ -872,7 +872,7 @@
     "timeJP": "2127",
     "timeCN": "2328",
     "onAirSite": [
-      "http://www.bilibili.com/sp/雨色可可",
+      "http://www.bilibili.com/bangumi/i/1550/",
       "http://www.tudou.com/albumcover/LdZ-0sB7aoY.html",
       "http://www.youku.com/show_page/id_z7d8b36f8d29b11e49e2a.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=雨色可可"
@@ -892,7 +892,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/I3F-I2rXmBI.html",
       "http://www.youku.com/show_page/id_z76ca4f38d29c11e4b8e3.html",
-      "http://www.bilibili.com/sp/攻壳机动队%20S.A.C#S-1791",
+      "http://www.bilibili.com/bangumi/i/1568/",
       "http://v.qq.com/detail/h/hp6xc4to1ytnkof.html",
       "http://www.acfun.tv/v/ab1470247_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=攻壳机动队ARISE"
@@ -974,7 +974,7 @@
       "http://www.youku.com/show_page/id_z2880e626d36311e49e2a.html",
       "http://www.tudou.com/albumcover/CoWG9Wl37gI.html",
       "http://www.pptv.com/page/318876.html",
-      "http://www.bilibili.com/sp/黏黏糊糊！！角质君#S-1817"
+      "http://www.bilibili.com/bangumi/i/1572/"
     ],
     "newBgm": true,
     "bgmId": 127172,
@@ -1029,7 +1029,7 @@
       "http://www.youku.com/show_page/id_z038f718ed35e11e49e2a.html",
       "http://www.tudou.com/albumcover/br_kIWGRomI.html",
       "http://www.pptv.com/page/311532.html",
-      "http://www.bilibili.com/sp/御神乐学园组曲",
+      "http://www.bilibili.com/bangumi/i/1548/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=御神乐学园组曲"
     ],
     "newBgm": true,
@@ -1048,7 +1048,7 @@
       "http://www.tudou.com/albumcover/hbSbEkGBZtk.html",
       "http://www.youku.com/show_page/id_z41f367f4d35f11e4b522.html",
       "http://www.letv.com/comic/10008635.html",
-      "http://www.bilibili.com/sp/吹响%21上低音号",
+      "http://www.bilibili.com/bangumi/i/1547/",
       "http://www.pptv.com/page/308933.html",
       "http://v.qq.com/detail/o/oesitw7dajrcifs.html",
       "http://www.acfun.tv/v/ab1470254_0",
@@ -1125,6 +1125,8 @@
     "timeCN": "2330",
     "onAirSite": [
       "http://www.pptv.com/page/305182.html",
+      "http://www.youku.com/show_page/id_z3ab8310ad2cd11e4b432.html",
+      "http://www.tudou.com/albumcover/czE_W65mzZk.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=放学后的昴星团"
     ],
     "newBgm": true,
@@ -1161,7 +1163,7 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_zab2bcd5cd37c11e4b432.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=punch+line",
-      "http://www.bilibili.com/sp/Punch%20Line"
+      "http://www.bilibili.com/bangumi/i/2541/"
     ],
     "newBgm": true,
     "bgmId": 118782,
@@ -1176,7 +1178,7 @@
     "timeJP": "0035",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/浦和小调",
+      "http://www.bilibili.com/bangumi/i/1597/",
       "http://www.letv.com/comic/10009011.html",
       "http://www.pptv.com/page/319016.html",
       "http://www.youku.com/show_page/id_z86145e1e080411e5a080.html",
@@ -1200,7 +1202,7 @@
       "http://www.youku.com/show_page/id_zcdd2de40d2c811e4b2ad.html",
       "http://www.letv.com/comic/10008544.html",
       "http://www.pptv.com/page/318508.html",
-      "http://www.bilibili.com/sp/伪恋#S-1801",
+      "http://www.bilibili.com/bangumi/i/1574/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=伪恋%20第二季"
     ],
     "newBgm": true,
@@ -1218,7 +1220,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/sdrYzuBFDuo.html",
       "http://www.youku.com/show_page/id_z94e46f16d2c511e4b692.html",
-      "http://www.bilibili.com/sp/希德尼娅的骑士#S-1796",
+      "http://www.bilibili.com/bangumi/i/1577/",
       "http://www.iqiyi.com/v_19rrnm1qek.html",
       "http://www.acfun.tv/v/ab1470262_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=希德尼娅的骑士%20第九行星战役"
@@ -1236,6 +1238,9 @@
     "timeJP": "0700",
     "timeCN": "",
     "onAirSite": [
+      "http://www.youku.com/show_page/id_z0a14b8a862d411e3a705.html",
+      "http://v.qq.com/detail/g/gkvdkxuaepreo2m.html",
+      "http://www.tudou.com/albumcover/0yYeCeFSZDo.html",
       "http://www.bilibili.com/sp/未来卡%20搭档对战#S-1814"
     ],
     "newBgm": true,
@@ -1304,7 +1309,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.pptv.com/page/319656.html",
-      "http://www.bilibili.com/sp/英国一家%20吃在日本",
+      "http://www.bilibili.com/bangumi/i/1738/",
       "http://www.acfun.tv/v/ab1470282_0"
     ],
     "newBgm": true,
@@ -1320,6 +1325,8 @@
     "timeJP": "2200",
     "timeCN": "2200",
     "onAirSite": [
+      "http://www.tudou.com/albumcover/thXrYtxFJfE.html",
+      "http://www.youku.com/show_page/id_z11209d22d2b511e4b432.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=忍者杀手"
     ],
     "newBgm": true,

--- a/json/bangumi-1507.json
+++ b/json/bangumi-1507.json
@@ -222,7 +222,7 @@
     "timeJP": "0125",
     "timeCN": "0510",
     "onAirSite": [
-      "http://www.bilibili.com/sp/食戟之灵",
+      "http://www.bilibili.com/bangumi/i/1559/",
       "http://www.iqiyi.com/a_19rrhay9y1.html",
       "http://www.letv.com/comic/10008945.html",
       "http://www.pptv.com/page/302468.html",
@@ -249,7 +249,7 @@
       "http://www.letv.com/comic/10008950.html",
       "http://www.tudou.com/albumcover/4f9dl2adFPg.html",
       "http://www.pptv.com/page/319657.html",
-      "http://www.bilibili.com/sp/宝石宠物#S-1811"
+      "http://www.bilibili.com/bangumi/i/1671/"
     ],
     "newBgm": false,
     "bgmId": 129823,
@@ -326,7 +326,7 @@
       "http://www.letv.com/comic/10008629.html",
       "http://v.qq.com/detail/2/2nqzaniq3tunys1.html",
       "http://www.pptv.com/page/305135.html",
-      "http://www.bilibili.com/sp/亚尔斯兰战记",
+      "http://www.bilibili.com/bangumi/i/1551/",
       "http://www.iqiyi.com/a_19rrhaybsx.html",
       "http://www.acfun.tv/v/ab1470244_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=亚尔斯兰战记"
@@ -422,7 +422,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.pptv.com/page/319656.html",
-      "http://www.bilibili.com/sp/英国一家%20吃在日本",
+      "http://www.bilibili.com/bangumi/i/1738/",
       "http://www.acfun.tv/v/ab1470282_0"
     ],
     "newBgm": false,
@@ -456,7 +456,7 @@
     "timeJP": "2330",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/我老婆是学生会长！",
+      "http://www.bilibili.com/bangumi/i/2600/",
       "http://www.acfun.tv/v/ab1470292_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=我老婆是学生会长"
     ],
@@ -474,8 +474,7 @@
     "timeJP": "0144",
     "timeCN": "",
     "onAirSite": [
-      "http://www.pptv.com/page/322253.html",
-      "http://www.bilibili.com/sp/GANGSTA.",
+      "http://www.bilibili.com/bangumi/i/2601/",
       "http://www.acfun.tv/v/ab1470326_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=GANGSTA"
     ],
@@ -496,7 +495,7 @@
       "http://www.tudou.com/albumcover/dIoKgU-j9O4.html",
       "http://www.youku.com/show_page/id_zb3f16e30197511e5b522.html",
       "http://www.pptv.com/page/321728.html",
-      "http://www.bilibili.com/sp/CHAOS%20DRAGON%20赤龙战役",
+      "http://www.bilibili.com/bangumi/i/2571/",
       "http://www.letv.com/comic/10010403.html",
       "http://v.qq.com/detail/s/s8q3rwmi1vcyhuu.html",
       "http://www.acfun.tv/v/ab1470293_0",
@@ -517,7 +516,7 @@
     "timeJP": "2300",
     "timeCN": "0030",
     "onAirSite": [
-      "http://www.bilibili.com/sp/创圣的大天使#S-1956",
+      "http://www.bilibili.com/bangumi/i/2579/",
       "http://www.letv.com/comic/10010420.html",
       "http://v.qq.com/detail/9/90ono2pk2blgqwd.html",
       "http://www.pptv.com/page/323242.html",
@@ -541,7 +540,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/bONAn7JK874.html",
       "http://www.youku.com/show_page/id_z8f02e3561a5611e5b5ce.html",
-      "http://www.bilibili.com/sp/乱步奇谭%20Game%20of%20Laplace",
+      "http://www.bilibili.com/bangumi/i/2585/",
       "http://www.letv.com/comic/10010419.html",
       "http://v.qq.com/detail/a/a3xvy009de4vael.html",
       "http://www.acfun.tv/v/ab1470321_0",
@@ -561,7 +560,7 @@
     "timeJP": "0046",
     "timeCN": "2100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/青春×机关枪",
+      "http://www.bilibili.com/bangumi/i/2589/",
       "http://www.iqiyi.com/a_19rrhb5qax.html",
       "http://v.qq.com/detail/1/1f1gzzkyhi264mg.html",
       "http://www.tudou.com/albumcover/3z2CdeVaST8.html",
@@ -586,7 +585,7 @@
       "http://www.pptv.com/page/323240.html",
       "http://www.tudou.com/albumcover/OJg0wZ-E11A.html",
       "http://www.youku.com/show_page/id_z5d031b5a198911e5b2ad.html",
-      "http://www.bilibili.com/sp/城下町的蒲公英",
+      "http://www.bilibili.com/bangumi/i/2613/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=城下町的蒲公英"
     ],
     "newBgm": true,
@@ -603,7 +602,7 @@
     "timeJP": "1100",
     "timeCN": "1200",
     "onAirSite": [
-      "http://www.bilibili.com/sp/黑塔利亚#S-1959",
+      "http://www.bilibili.com/bangumi/i/2581/",
       "http://www.youku.com/show_page/id_zccc269fe1a5711e59e2a.html",
       "http://www.tudou.com/albumcover/VV4mMWDU6nA.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=黑塔利亚%20The%20World%20Twinkle"
@@ -641,7 +640,7 @@
     "timeJP": "2130",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/黑白小姐#S-1954",
+      "http://www.bilibili.com/bangumi/i/2617/",
       "http://www.youku.com/show_page/id_z7c16449c198c11e59e2a.html",
       "http://www.acfun.tv/v/ab1470299_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=黑白小姐%20第二季"
@@ -660,7 +659,7 @@
     "timeJP": "2209",
     "timeCN": "2220",
     "onAirSite": [
-      "http://www.bilibili.com/sp/乌瑟的穷困生活#S-1952",
+      "http://www.bilibili.com/bangumi/i/2615/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=T宝的悲惨日常%20梦幻篇"
     ],
     "newBgm": true,
@@ -677,7 +676,7 @@
     "timeJP": "2140",
     "timeCN": "2225",
     "onAirSite": [
-      "http://www.bilibili.com/sp/若叶女孩",
+      "http://www.bilibili.com/bangumi/i/2590/",
       "http://www.tudou.com/albumcover/2xZbLVJzdxk.html",
       "http://www.youku.com/show_page/id_z5a5b31301a5111e5abda.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=若叶女孩"
@@ -701,7 +700,7 @@
       "http://www.pptv.com/page/308881.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=GATE奇幻自卫队",
       "http://www.acfun.tv/v/ab1470300_0",
-      "http://www.bilibili.com/sp/GATE%20奇幻自卫队"
+      "http://www.bilibili.com/bangumi/i/2618/"
     ],
     "newBgm": true,
     "showDate": "2015-07-03",
@@ -717,7 +716,7 @@
     "timeJP": "0055",
     "timeCN": "0225",
     "onAirSite": [
-      "http://www.bilibili.com/sp/Classroom☆Crisis",
+      "http://www.bilibili.com/bangumi/i/2582/",
       "http://www.youku.com/show_page/id_z698d6ccc1aec11e5b692.html",
       "http://www.tudou.com/albumcover/WQW4z5dDdEo.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=Classroom☆Crisis"
@@ -736,7 +735,7 @@
     "timeJP": "0210",
     "timeCN": "0310",
     "onAirSite": [
-      "http://www.bilibili.com/sp/战姬绝唱SYMPHOGEAR#S-1957",
+      "http://www.bilibili.com/bangumi/i/2621/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=战姬绝唱Symphogear%20GX",
       "http://www.acfun.tv/v/ab1470332_0",
       "http://www.letv.com/comic/10010494.html",
@@ -759,7 +758,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/Se7oGWDr_GA.html",
       "http://www.youku.com/show_page/id_z2c9c7552acd811e38b3f.html",
-      "http://www.bilibili.com/sp/无头骑士异闻录#S-1995",
+      "http://www.bilibili.com/bangumi/i/2595/",
       "http://v.qq.com/detail/4/4gmobofw9fltve9.html",
       "http://www.iqiyi.com/a_19rrhay53x.html",
       "http://www.acfun.tv/v/ab1470302_0",
@@ -782,7 +781,7 @@
       "http://www.tudou.com/albumcover/tO8jG72LwdY.html",
       "http://www.youku.com/show_page/id_z074ab022197c11e5b5ce.html",
       "http://www.pptv.com/page/308880.html",
-      "http://www.bilibili.com/sp/Charlotte",
+      "http://www.bilibili.com/bangumi/i/2572/",
       "http://www.letv.com/comic/10010346.html",
       "http://www.iqiyi.com/a_19rrhb5qhd.html",
       "http://v.qq.com/detail/k/keh8jx4nea7e5w0.html",
@@ -803,7 +802,7 @@
     "timeJP": "2330",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/WORKING!!迷糊餐厅#S-1960",
+      "http://www.bilibili.com/bangumi/i/2587/",
       "http://www.youku.com/show_page/id_z21b943001af911e5b2ad.html",
       "http://www.tudou.com/albumcover/OWrP8KCU_84.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=WORKING!!!迷糊餐厅%20第三季"
@@ -822,7 +821,7 @@
     "timeJP": "2200",
     "timeCN": "0200",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/没有黄段子存在的无聊世界/",
+      "http://www.bilibili.com/bangumi/i/2586/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=下流梗不存在的灰暗世界"
     ],
     "newBgm": true,
@@ -878,7 +877,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/8nSAQ0J0quI.html",
       "http://www.youku.com/show_page/id_ze86a7b88197611e5b5ce.html",
-      "http://www.bilibili.com/sp/六花的勇者",
+      "http://www.bilibili.com/bangumi/i/2584/",
       "http://www.letv.com/comic/10010418.html",
       "http://www.pptv.com/page/323039.html",
       "http://www.iqiyi.com/a_19rrhb5knt.html",
@@ -918,7 +917,7 @@
     "onAirSite": [
       "http://www.acfun.tv/v/ab1470306_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=和歌子酒",
-      "http://www.bilibili.com/sp/和歌子酒%20动画",
+      "http://www.bilibili.com/bangumi/i/2602/",
       "http://www.youku.com/show_page/id_zcbe6bddc1afc11e5b2ad.html",
       "http://www.tudou.com/albumcover/hAbiy9lIw6k.html"
     ],
@@ -938,7 +937,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/n3RSRsUtHhk.html",
       "http://www.youku.com/show_page/id_z7f52b0ce197c11e5a080.html",
-      "http://www.bilibili.com/sp/噬神者",
+      "http://www.bilibili.com/bangumi/i/2591/",
       "http://www.letv.com/comic/10010338.html",
       "http://v.qq.com/detail/w/wdp6c3tyxfha0l8.html",
       "http://www.iqiyi.com/a_19rrhb5by1.html",
@@ -959,7 +958,7 @@
     "timeJP": "1755",
     "timeCN": "",
     "onAirSite": [
-      "http://www.letv.com/comic/10007850.html"
+      "http://www.bilibili.com/sp/Q版变形金刚%20归来的擎天柱之谜#S-2010"
     ],
     "newBgm": true,
     "showDate": "2015-07-06",
@@ -977,7 +976,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/StDyVAcEEkA.html",
       "http://www.youku.com/show_page/id_z389e1aea197e11e5b5ce.html",
-      "http://www.bilibili.com/sp/赤发白雪姬",
+      "http://www.bilibili.com/bangumi/i/2578/",
       "http://www.iqiyi.com/a_19rrhb5pv5.html",
       "http://v.qq.com/detail/2/2hndczgdvkpzff5.html",
       "http://www.acfun.tv/v/ab1470308_0",
@@ -1015,7 +1014,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.acfun.tv/v/ab1470290_0",
-      "http://www.bilibili.com/bangumi/网球并不可笑嘛%20第五季/",
+      "http://www.bilibili.com/bangumi/i/2604/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=网球并不可笑嘛Ⅴ"
     ],
     "newBgm": true,
@@ -1070,7 +1069,7 @@
     "timeJP": "0011",
     "timeCN": "0020",
     "onAirSite": [
-      "http://www.bilibili.com/sp/Million%20Doll",
+      "http://www.bilibili.com/bangumi/i/2577/",
       "http://www.youku.com/show_page/id_z6627edf21afe11e5b5ce.html",
       "http://www.tudou.com/albumcover/ZTzQXgNfUcg.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=Million%20Doll"
@@ -1091,7 +1090,7 @@
     "onAirSite": [
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=怪兽酒场干杯！",
       "http://www.acfun.tv/v/ab1470311_0",
-      "http://www.bilibili.com/bangumi/怪兽酒场干杯！/",
+      "http://www.bilibili.com/bangumi/i/2608/",
       "http://www.youku.com/show_page/id_z14019f301b1411e5b522.html",
       "http://www.tudou.com/albumcover/-ScJYfqsTf4.html",
       "http://www.pptv.com/page/324423.html"
@@ -1110,7 +1109,7 @@
     "timeJP": "2200",
     "timeCN": "2300",
     "onAirSite": [
-      "http://www.bilibili.com/sp/OVER%20LORD",
+      "http://www.bilibili.com/bangumi/i/2576/",
       "http://www.youku.com/show_page/id_z64aa68201afd11e5b432.html",
       "http://www.tudou.com/albumcover/q-oIiGcAaiI.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=Overlord"
@@ -1129,7 +1128,7 @@
     "timeJP": "2200",
     "timeCN": "0430",
     "onAirSite": [
-      "http://www.bilibili.com/sp/那就是声优！",
+      "http://www.bilibili.com/bangumi/i/2588/",
       "http://www.youku.com/show_page/id_zfe0c3a541b1411e5b692.html",
       "http://www.tudou.com/albumcover/muSo-21H4qo.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=那就是声优"
@@ -1150,7 +1149,7 @@
     "onAirSite": [
       "http://v.qq.com/detail/8/8yjy00f3wg1tz63.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=魔物娘的相伴日常",
-      "http://www.bilibili.com/bangumi/魔物娘的相伴日常/"
+      "http://www.bilibili.com/bangumi/i/2624/"
     ],
     "newBgm": true,
     "showDate": "2015-07-07",
@@ -1169,7 +1168,7 @@
       "http://www.letv.com/comic/10010613.html",
       "http://www.acfun.tv/v/ab1470313_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=比基尼勇士",
-      "http://www.bilibili.com/bangumi/比基尼勇士/"
+      "http://www.bilibili.com/bangumi/i/2609/"
     ],
     "newBgm": true,
     "showDate": "2015-07-08",
@@ -1185,7 +1184,7 @@
     "timeJP": "2055",
     "timeCN": "2055",
     "onAirSite": [
-      "http://www.bilibili.com/sp/洲崎西",
+      "http://www.bilibili.com/bangumi/i/2593/",
       "http://www.youku.com/show_page/id_ze09e684a1ae511e5a080.html",
       "http://www.tudou.com/albumcover/dJ1sytgsCa4.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=洲崎西"
@@ -1204,7 +1203,7 @@
     "timeJP": "2330",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/sp/空战魔导士候补生的教官",
+      "http://www.bilibili.com/bangumi/i/2583/",
       "http://v.qq.com/detail/a/aan1um3pt3nue20.html",
       "http://www.youku.com/show_page/id_z1675c8261afc11e5b5ce.html",
       "http://www.tudou.com/albumcover/5Uc8Zc-opHo.html",
@@ -1242,7 +1241,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/4IsZAYXiK2M.html",
       "http://www.youku.com/show_page/id_zc4d8c0401afb11e5b5ce.html",
-      "http://www.bilibili.com/sp/干物妹！小埋",
+      "http://www.bilibili.com/bangumi/i/2580/",
       "http://www.letv.com/comic/10010414.html",
       "http://v.qq.com/detail/3/3lriily11h16j01.html",
       "http://www.iqiyi.com/a_19rrhb5bo5.html",
@@ -1263,7 +1262,7 @@
     "timeJP": "2030",
     "timeCN": "0200",
     "onAirSite": [
-      "http://www.bilibili.com/sp/学园孤岛",
+      "http://www.bilibili.com/bangumi/i/2592/",
       "http://v.qq.com/detail/f/f6za0go0jf6fzrm.html",
       "http://www.youku.com/show_page/id_z9e7a96501af911e5b432.html",
       "http://www.tudou.com/albumcover/VS6KqsiOduc.html",
@@ -1283,7 +1282,7 @@
     "timeJP": "0000",
     "timeCN": "0015",
     "onAirSite": [
-      "http://www.bilibili.com/sp/群居姐妹",
+      "http://www.bilibili.com/bangumi/i/2614/",
       "http://www.youku.com/show_page/id_zff6613541af911e5b5ce.html",
       "http://www.tudou.com/albumcover/jMT-3fMlm9I.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=群居姐妹"
@@ -1320,7 +1319,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.acfun.tv/v/ab1470305_0",
-      "http://www.bilibili.com/bangumi/VENUS%20PROJECT%20-CLIMAX-/",
+      "http://www.bilibili.com/bangumi/i/2599/",
       "http://www.pptv.com/page/324993.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=VENUS%20PROJECT"
     ],
@@ -1339,7 +1338,7 @@
     "timeCN": "0015",
     "onAirSite": [
       "http://v.qq.com/detail/v/vxk0pmz40gf0hz0.html",
-      "http://www.bilibili.com/sp/枕男子",
+      "http://www.bilibili.com/bangumi/i/2610/",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=枕男子"
     ],
     "newBgm": true,
@@ -1356,7 +1355,7 @@
     "timeJP": "2300",
     "timeCN": "0030",
     "onAirSite": [
-      "http://www.bilibili.com/sp/偶像大师%20灰姑娘女孩",
+      "http://www.bilibili.com/bangumi/i/2594/",
       "http://www.tudou.com/albumcover/qgdKuHlPg9g.html",
       "http://www.youku.com/show_page/id_z1e13314abec311e38b3f.html",
       "http://www.acfun.tv/v/ab1470343_0",
@@ -1381,7 +1380,7 @@
     "timeJP": "0040",
     "timeCN": "0210",
     "onAirSite": [
-      "http://www.bilibili.com/sp/魔法少女☆伊莉雅#S-1955",
+      "http://www.bilibili.com/bangumi/i/2575/",
       "http://www.acfun.tv/v/ab1470318_0",
       "http://www.iqiyi.com/a_19rrhb5qkt.html",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&catid=24&q=魔法少女☆伊莉雅%202wei%20Herz!"
@@ -1404,7 +1403,7 @@
       "http://www.youku.com/show_page/id_z3eebb5a2d1f711e4abda.html",
       "http://v.qq.com/detail/l/l2h6j510vy2r11e.html",
       "http://www.letv.com/comic/10008624.html",
-      "http://www.bilibili.com/sp/小长门有希的消失",
+      "http://www.bilibili.com/bangumi/i/1558/",
       "http://www.acfun.tv/v/ab1470229_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=小长门有希的消失"
     ],
@@ -1428,7 +1427,7 @@
       "http://www.letv.com/comic/10008625.html",
       "http://www.pptv.com/page/309013.html",
       "http://www.iqiyi.com/a_19rrhay9bt.html",
-      "http://www.bilibili.com/sp/KEKKAI%20SENSEN",
+      "http://www.bilibili.com/bangumi/i/1553/",
       "http://www.acfun.tv/v/ab1470243_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=血界战线"
     ],
@@ -1450,7 +1449,7 @@
       "http://www.tudou.com/albumcover/5EughhrPa3A.html",
       "http://www.youku.com/show_page/id_z460a9d2cd29611e4a080.html",
       "http://www.iqiyi.com/a_19rrhaybvd.html",
-      "http://www.bilibili.com/sp/BABY%20STEPS%20网球优等生#S-1808",
+      "http://www.bilibili.com/bangumi/i/1652/",
       "http://www.acfun.tv/v/ab1470246_0",
       "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=网球优等生%20第二季"
     ],


### PR DESCRIPTION
更新 Bilibili 链接.
如果某链接无 hash 而之后有新一季出来导致指向不正确, 我的程序是没有进行检测直接替换的, 可能会有部分链接不正确, 因为原来就不正确.
文件中没有替换的那些链接绝大多数都是已下架的, 少数是其链接直接跳转到其他正版站.
其中__四月是你的谎言__其[专题页面](http://www.bilibili.com/sp/四月是你的谎言)是包含全集和分开的各集, 而其[番剧页面](http://www.bilibili.com/bangumi/i/1699/)只有全集, 我依然改成了番剧链接.