### PR TITLE
减小日期分割时间的最小值

### DIFF
--- a/src/js/store/BgmConfigStore.js
+++ b/src/js/store/BgmConfigStore.js
@@ -17,7 +17,7 @@ var DEFAULT = {
     jpTitle: false,
     dayDivide: 24,
     dayDivideMax: 24,
-    dayDivideMin: 20
+    dayDivideMin: 5
 };
 
 var BgmConfigStore = _.assign({}, EventEmitter.prototype, {


### PR DESCRIPTION
希望这个设置可以更灵活一些。

我个人会把这个时间设置为12点（实际上是10点因为我在UTC+10），因为我有时安排在午饭后看番，所以那之后出的番有可能会安排到下一天，所以希望能够将日期分割时间设置得更小。（虽然说我通过在本地修改`localStorage`存储的值实际上已经做到了……）