### PR TITLE
更新 1410 的数据

### DIFF
--- a/json/bangumi-1410.json
+++ b/json/bangumi-1410.json
@@ -921,7 +921,7 @@
       "http://www.tudou.com/albumcover/CIK0mT03n_M.html",
       "http://www.youku.com/show_page/id_zca5b9dc41c3f11e3b8b7.html",
       "http://www.le.com/comic/93548.html",
-      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=%E5%AE%A0%E7%89%A9%E5%B0%8F%E7%B2%BE%E7%81%B5XY"
+      "http://www.tucao.tv/index.php?m=search&c=index&a=init2&q=%E5%AE%A0%E7%89%A9%E5%B0%8F%E7%B2%BE%E7%81%B5XY"
     ],
     "newBgm": false,
     "bgmId": 78799,

--- a/json/bangumi-1410.json
+++ b/json/bangumi-1410.json
@@ -8,12 +8,11 @@
     "timeJP": "1800",
     "timeCN": "",
     "onAirSite": [
-      "http://www.acfun.tv/a/aa127_0",
       "http://www.iqiyi.com/a_19rrhc0gyd.html",
       "http://v.qq.com/detail/h/hzgtnf6tbvfekfv.html",
       "http://tv.sohu.com/s2012/mztkn/",
-      "http://www.letv.com/comic/5938.html",
-      "http://www.pptv.com/page/2815.html"
+      "http://www.le.com/comic/5938.html",
+      "http://v.pptv.com/page/ac24Np4EdLIVkics.html"
     ],
     "newBgm": false,
     "bgmId": 899,
@@ -28,11 +27,9 @@
     "timeJP": "0930",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/海贼王",
-      "http://www.acfun.tv/a/aa126_0",
       "http://tv.sohu.com/s2013/onepiece/",
       "http://www.iqiyi.com/a_19rrhb3xvl.html",
-      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=海贼王"
+      "http://www.tucao.tv/index.php?m=search&c=index&a=init2&q=海贼王"
     ],
     "newBgm": false,
     "bgmId": 975,
@@ -48,9 +45,8 @@
     "timeCN": "1900",
     "onAirSite": [
       "http://www.tudou.com/albumcover/Lqfme5hSolM.html",
-      "http://www.bilibili.com/sp/火影忍者",
       "http://www.youku.com/show_page/id_zcc001f06962411de83b1.html",
-      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=火影忍者"
+      "http://www.tucao.tv/index.php?m=search&c=index&a=init2&q=火影忍者"
     ],
     "newBgm": false,
     "bgmId": 2782,
@@ -65,8 +61,6 @@
     "timeJP": "1700",
     "timeCN": "1900",
     "onAirSite": [
-      "http://www.bilibili.com/sp/偶像活动",
-      "http://www.acfun.tv/a/aa1464858",
       "http://www.iqiyi.com/a_19rrhc0yjx.html"
     ],
     "newBgm": true,
@@ -82,11 +76,11 @@
     "timeJP": "1630",
     "timeCN": "",
     "onAirSite": [
-      "http://www.letv.com/comic/10000913.html",
-      "http://www.pptv.com/page/286416.html",
+      "http://www.le.com/comic/10000913.html",
+      "http://v.pptv.com/page/afDcWsIomNY5tx8.html",
       "http://www.youku.com/show_page/id_z40c8abaa99e511e3b8b7.html",
       "http://www.tudou.com/albumcover/j6bLOojGi-I.html",
-      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=游戏王ARC-V"
+      "http://www.tucao.tv/index.php?m=search&c=index&a=init2&q=游戏王ARC-V"
     ],
     "newBgm": false,
     "bgmId": 92161,
@@ -101,9 +95,7 @@
     "timeJP": "2100",
     "timeCN": "2200",
     "onAirSite": [
-      "http://www.youku.com/show_page/id_za5f390803ed111e4b2ad.html",
-      "http://www.tudou.com/albumcover/V6JR5hlW_vs.html",
-      "http://www.bilibili.com/bangumi/i/321/"
+      "http://bangumi.bilibili.com/anime/321/"
     ],
     "newBgm": true,
     "bgmId": 101784,
@@ -118,10 +110,7 @@
     "timeJP": "1800",
     "timeCN": "2148",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/328/",
-      "http://www.tudou.com/albumcover/jPC-noZzwUA.html",
-      "http://www.youku.com/show_page/id_z730c84360fee11e48b3f.html",
-      "http://www.acfun.tv/a/aa1464843"
+      "http://bangumi.bilibili.com/anime/328"
     ],
     "newBgm": true,
     "bgmId": 96113,
@@ -135,11 +124,7 @@
     "weekDayCN": 4,
     "timeJP": "0029",
     "timeCN": "0330",
-    "onAirSite": [
-      "http://www.tudou.com/albumcover/ljWaEal7TxI.html",
-      "http://www.bilibili.com/sp/寄生兽",
-      "http://www.acfun.tv/v/ab1464806"
-    ],
+    "onAirSite": [],
     "newBgm": true,
     "bgmId": 88433,
     "showDate": "2014-10-09"
@@ -153,9 +138,7 @@
     "timeJP": "0058",
     "timeCN": "0430",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0xl1.html",
-      "http://www.acfun.tv/a/aa1464836",
-      "http://www.bilibili.com/sp/笑对阴天"
+      "http://www.iqiyi.com/a_19rrhc0xl1.html"
     ],
     "newBgm": true,
     "bgmId": 80837,
@@ -170,13 +153,12 @@
     "timeJP": "0116",
     "timeCN": "",
     "onAirSite": [
-      "http://www.letv.com/comic/10005260.html",
+      "http://www.le.com/comic/10005260.html",
       "http://v.qq.com/detail/w/wt2ko9mlf02fryc.html",
-      "http://www.pptv.com/page/296388.html",
+      "http://v.pptv.com/page/gKKODHTaSojradE.html",
       "http://www.youku.com/show_page/id_z8c74cc8ace7611e3a705.html",
       "http://www.tudou.com/albumcover/7CNapiWZqVk.html",
-      "http://www.bilibili.com/bangumi/i/281/",
-      "http://www.acfun.tv/a/aa1464810"
+      "http://bangumi.bilibili.com/anime/281"
     ],
     "newBgm": true,
     "bgmId": 93545,
@@ -192,9 +174,7 @@
     "timeCN": "0349",
     "onAirSite": [
       "http://www.tudou.com/albumcover/iU6KdfiaSxo.html",
-      "http://www.youku.com/show_page/id_z21e664b6b01011e3a705.html",
-      "http://www.bilibili.com/sp/高达G之复国运动",
-      "http://www.acfun.tv/v/ab1464804"
+      "http://www.youku.com/show_page/id_z21e664b6b01011e3a705.html"
     ],
     "newBgm": true,
     "bgmId": 54551,
@@ -209,10 +189,9 @@
     "timeJP": "0046",
     "timeCN": "0246",
     "onAirSite": [
-      "http://www.letv.com/comic/10005167.html",
+      "http://www.le.com/comic/10005167.html",
       "http://www.iqiyi.com/a_19rrhbzehh.html",
-      "http://www.bilibili.com/bangumi/i/324/",
-      "http://www.acfun.tv/a/aa1464824"
+      "http://bangumi.bilibili.com/anime/324"
     ],
     "newBgm": true,
     "bgmId": 92429,
@@ -228,8 +207,7 @@
     "timeCN": "",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhbz0ah.html",
-      "http://www.bilibili.com/sp/早安恋味糕点店",
-      "http://www.acfun.tv/a/aa1464826"
+      "http://bangumi.bilibili.com/anime/3070/"
     ],
     "newBgm": true,
     "bgmId": 110485,
@@ -244,9 +222,7 @@
     "timeJP": "0119",
     "timeCN": "0350",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhbyz99.html",
-      "http://www.bilibili.com/sp/结城友奈是勇者",
-      "http://www.acfun.tv/a/aa1464812"
+      "http://www.iqiyi.com/a_19rrhbyz99.html"
     ],
     "newBgm": true,
     "bgmId": 109328,
@@ -262,8 +238,7 @@
     "timeCN": "2330",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhbzeox.html",
-      "http://www.acfun.tv/v/ab1464814",
-      "http://www.bilibili.com/sp/SHIROBAKO"
+      "http://www.acfun.tv/v/ab1464814"
     ],
     "newBgm": true,
     "bgmId": 110467,
@@ -278,12 +253,11 @@
     "timeJP": "2254",
     "timeCN": "2301",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/311/",
+      "http://bangumi.bilibili.com/anime/311",
       "http://www.iqiyi.com/a_19rrhc0z1p.html",
       "http://v.qq.com/detail/v/vkvksohhix5upx7.html",
       "http://www.youku.com/show_page/id_z49e9085a3d6a11e4b522.html",
-      "http://www.tudou.com/albumcover/Nb_J8BL62Pc.html",
-      "http://www.acfun.tv/a/aa1464850"
+      "http://www.tudou.com/albumcover/Nb_J8BL62Pc.html"
     ],
     "newBgm": true,
     "bgmId": 104138,
@@ -297,13 +271,7 @@
     "weekDayCN": 3,
     "timeJP": "1700",
     "timeCN": "1900",
-    "onAirSite": [
-      "http://www.tudou.com/albumcover/52Lw1YgzskQ.html",
-      "http://www.youku.com/show_page/id_z0a038a9e29c411e48b3f.html",
-      "http://www.iqiyi.com/a_19rrhc0r3l.html",
-      "http://www.acfun.tv/v/ab1464844",
-      "http://www.bilibili.com/sp/高达BUILD%20FIGHTERS#S-1332"
-    ],
+    "onAirSite": [],
     "newBgm": true,
     "bgmId": 105875,
     "showDate": "2014-10-08"
@@ -317,10 +285,7 @@
     "timeJP": "2130",
     "timeCN": "2230",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/296/",
-      "http://www.tudou.com/albumcover/k8qIX3LeVBw.html",
-      "http://www.youku.com/show_page/id_z7f0ea2e2bd4511e3a705.html",
-      "http://www.acfun.tv/a/aa1464809"
+      "http://bangumi.bilibili.com/anime/296"
     ],
     "newBgm": true,
     "bgmId": 100040,
@@ -335,10 +300,7 @@
     "timeJP": "2130",
     "timeCN": "2330",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/282/",
-      "http://www.youku.com/show_page/id_ze4002ea421d211e4a705.html",
-      "http://www.tudou.com/albumcover/t_PmumgmCd0.html",
-      "http://www.acfun.tv/a/aa1464849"
+      "http://bangumi.bilibili.com/anime/282"
     ],
     "newBgm": true,
     "bgmId": 103127,
@@ -353,9 +315,7 @@
     "timeJP": "1930",
     "timeCN": "0130",
     "onAirSite": [
-      "http://www.bilibili.com/sp/寻找失去的未来",
-      "http://www.iqiyi.com/a_19rrhc108x.html",
-      "http://www.acfun.tv/a/aa1464840"
+      "http://www.iqiyi.com/a_19rrhc108x.html"
     ],
     "newBgm": true,
     "bgmId": 91985,
@@ -371,8 +331,7 @@
     "timeCN": "0135",
     "onAirSite": [
       "http://v.qq.com/detail/c/crrtngniol48xnn.html",
-      "http://www.bilibili.com/bangumi/i/188/",
-      "http://www.acfun.tv/a/aa1464827"
+      "http://bangumi.bilibili.com/anime/188"
     ],
     "newBgm": true,
     "bgmId": 104219,
@@ -391,9 +350,9 @@
       "http://www.tudou.com/albumcover/RsfQldH8q6s.html",
       "http://v.qq.com/detail/5/54v59r074ncc1kq.html",
       "http://www.youku.com/show_page/id_z46465a1c711f11e38b3f.html",
-      "http://www.letv.com/comic/10005152.html",
-      "http://www.bilibili.com/bangumi/i/1586/",
-      "http://www.acfun.tv/a/aa1464802"
+      "http://www.le.com/comic/10005152.html",
+      "http://bangumi.bilibili.com/anime/1586",
+      "http://www.acfun.tv/v/ab1464802"
     ],
     "newBgm": true,
     "bgmId": 95225,
@@ -409,9 +368,7 @@
     "timeCN": "0400",
     "onAirSite": [
       "http://tv.sohu.com/s2014/csxz/",
-      "http://www.tudou.com/albumcover/gzcFORsqmzM.html",
-      "http://www.youku.com/show_page/id_z3b94454c75d511e3a705.html",
-      "http://www.bilibili.com/sp/虫师#S-1335"
+      "http://bangumi.bilibili.com/anime/1715"
     ],
     "newBgm": true,
     "bgmId": 106207,
@@ -426,9 +383,7 @@
     "timeJP": "2100",
     "timeCN": "2330",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0zph.html",
-      "http://www.acfun.tv/a/aa1464857",
-      "http://www.bilibili.com/sp/狼少女与黑王子"
+      "http://www.iqiyi.com/a_19rrhc0zph.html"
     ],
     "newBgm": true,
     "bgmId": 101518,
@@ -445,8 +400,6 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/jGaFpdJqObQ.html",
       "http://www.youku.com/show_page/id_zff86b776cf5f11e3b8b7.html",
-      "http://www.bilibili.com/sp/火星异种#S-1323",
-      "http://www.acfun.tv/a/aa1464218",
       "http://www.iqiyi.com/a_19rrhc139h.html"
     ],
     "newBgm": true,
@@ -463,10 +416,7 @@
     "timeCN": "1700",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0zv1.html",
-      "http://www.tudou.com/albumcover/lHvXdgRhkLc.html",
-      "http://www.youku.com/show_page/id_zbf2687ec1d0c11e4b2ad.html",
-      "http://www.acfun.tv/v/ab1464811",
-      "http://www.bilibili.com/sp/CROSSANGE%20天使与龙的轮舞"
+      "http://bangumi.bilibili.com/anime/3048"
     ],
     "newBgm": true,
     "bgmId": 109948,
@@ -482,9 +432,8 @@
     "timeCN": "2230",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0xbh.html",
-      "http://www.bilibili.com/bangumi/i/291/",
-      "http://www.acfun.tv/a/aa1464820",
-      "http://www.pptv.com/page/268775.html",
+      "http://bangumi.bilibili.com/anime/291",
+      "http://v.pptv.com/page/srmTEXnfT43wbtY.html",
       "http://www.youku.com/show_page/id_z17369f303d6511e4b2ad.html",
       "http://www.tudou.com/albumcover/66Gn16iu3K4.html"
     ],
@@ -501,9 +450,7 @@
     "timeJP": "0005",
     "timeCN": "0205",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0xpd.html",
-      "http://www.bilibili.com/sp/选择感染者WIXOSS",
-      "http://www.acfun.tv/a/aa1464830"
+      "http://www.iqiyi.com/a_19rrhc0xpd.html"
     ],
     "newBgm": true,
     "bgmId": 106314,
@@ -520,9 +467,8 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/3sgyRBy1t1M.html",
       "http://www.youku.com/show_page/id_zd6c247ae3d6b11e4a080.html",
-      "http://www.bilibili.com/bangumi/i/318/",
       "http://www.iqiyi.com/a_19rrhc0ytd.html",
-      "http://www.pptv.com/page/296315.html",
+      "http://v.pptv.com/page/e923NZ0Dc7EUkvo.html",
       "http://www.acfun.tv/v/ab1464837"
     ],
     "newBgm": true,
@@ -538,9 +484,7 @@
     "timeJP": "2230",
     "timeCN": "0200",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0z39.html",
-      "http://www.bilibili.com/sp/巴哈姆特之怒",
-      "http://www.acfun.tv/a/aa1464822"
+      "http://www.iqiyi.com/a_19rrhc0z39.html"
     ],
     "newBgm": true,
     "bgmId": 91986,
@@ -555,9 +499,7 @@
     "timeJP": "1930",
     "timeCN": "0000",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0zfl.html",
-      "http://www.acfun.tv/a/aa1464838",
-      "http://www.bilibili.com/sp/灰色的果实"
+      "http://www.iqiyi.com/a_19rrhc0zfl.html"
     ],
     "newBgm": true,
     "bgmId": 67376,
@@ -572,10 +514,7 @@
     "timeJP": "1600",
     "timeCN": "2100",
     "onAirSite": [
-      "http://tv.sohu.com/s2014/dhpqyz/",
-      "http://www.iqiyi.com/a_19rrhc0zl5.html",
-      "http://www.bilibili.com/sp/七大罪",
-      "http://www.acfun.tv/v/ab1464817"
+      "http://www.bilibili.com/sp/七大罪"
     ],
     "newBgm": true,
     "bgmId": 101820,
@@ -593,10 +532,8 @@
       "http://v.qq.com/detail/f/fm95ukbvs36ejzw.html",
       "http://www.youku.com/show_page/id_zeebadce421c911e4a705.html",
       "http://www.tudou.com/albumcover/2TdJoRW10F8.html",
-      "http://www.acfun.tv/a/aa1464847",
       "http://www.iqiyi.com/a_19rrhc0x81.html",
-      "http://tv.sohu.com/s2014/gdjd1412/",
-      "http://www.bilibili.com/sp/魔术快斗"
+      "http://tv.sohu.com/s2014/gdjd1412/"
     ],
     "newBgm": true,
     "bgmId": 109203,
@@ -611,9 +548,6 @@
     "timeJP": "0600",
     "timeCN": "1435",
     "onAirSite": [
-      "http://www.acfun.tv/a/aa1464859",
-      "http://www.bilibili.com/sp/TRIBECOOLCREW",
-      "http://www.youku.com/show_page/id_z1543189e3ed611e4b522.html",
       "http://www.iqiyi.com/a_19rrhc0yh5.html"
     ],
     "newBgm": true,
@@ -629,9 +563,7 @@
     "timeJP": "0530",
     "timeCN": "1100",
     "onAirSite": [
-      "http://www.iqiyi.com/a_19rrhc0zzx.html",
-      "http://www.acfun.tv/a/aa1464845",
-      "http://www.bilibili.com/sp/境界触发者"
+      "http://www.iqiyi.com/a_19rrhc0zzx.html"
     ],
     "newBgm": true,
     "bgmId": 104906,
@@ -648,8 +580,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0xnt.html",
       "http://www.tudou.com/albumcover/gdZUtuYLZdw.html",
-      "http://www.bilibili.com/sp/牙狼%20炎之刻印",
-      "http://www.acfun.tv/a/aa1464805",
+      "http://bangumi.bilibili.com/anime/3209",
       "http://www.youku.com/show_page/id_z7d04ee48fa7b11e3b8b7.html"
     ],
     "newBgm": true,
@@ -666,11 +597,10 @@
     "timeCN": "0105",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc0zdp.html",
-      "http://www.pptv.com/page/291767.html",
+      "http://v.pptv.com/page/FTUfnQVr2xl8ibmI.html",
       "http://www.youku.com/show_page/id_ze31f4ef6c92211e3a705.html",
       "http://www.tudou.com/albumcover/pPuLbZdMqTY.html",
-      "http://www.acfun.tv/a/aa1464821",
-      "http://www.bilibili.com/bangumi/i/297/"
+      "http://bangumi.bilibili.com/anime/297"
     ],
     "newBgm": true,
     "bgmId": 100227,
@@ -686,9 +616,7 @@
     "timeCN": "0135",
     "onAirSite": [
       "http://www.tudou.com/albumcover/0-8oH78hMeI.html",
-      "http://www.youku.com/show_page/id_za2826926df3611e3b8b7.html",
-      "http://www.bilibili.com/sp/飙速宅男#S-1337",
-      "http://www.acfun.tv/v/ab1464828"
+      "http://www.youku.com/show_page/id_za2826926df3611e3b8b7.html"
     ],
     "newBgm": true,
     "bgmId": 104468,
@@ -702,10 +630,7 @@
     "weekDayCN": 5,
     "timeJP": "2350",
     "timeCN": "0030",
-    "onAirSite": [
-      "http://www.letv.com/comic/10004904.html",
-      "http://www.bilibili.com/sp/PSYCHO-PASS#S-1339"
-    ],
+    "onAirSite": [],
     "newBgm": true,
     "bgmId": 77625,
     "showDate": "2014-10-09"
@@ -719,12 +644,11 @@
     "timeJP": "1630",
     "timeCN": "0100",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/290/",
-      "http://www.pptv.com/page/297514.html",
+      "http://bangumi.bilibili.com/anime/290",
+      "http://v.pptv.com/page/ibVs1sxuB8SibSEHg.html",
       "http://www.iqiyi.com/a_19rrhc10bp.html",
       "http://www.youku.com/show_page/id_z78f9354e3d6411e4a080.html",
-      "http://www.tudou.com/albumcover/v7h-gGVVx6U.html",
-      "http://www.acfun.tv/v/ab1464807"
+      "http://www.tudou.com/albumcover/v7h-gGVVx6U.html"
     ],
     "newBgm": true,
     "bgmId": 100517,
@@ -741,7 +665,7 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/vVolwaPqgHI.html",
       "http://www.youku.com/show_page/id_z75eea0d2b24a11e38b3f.html",
-      "http://www.bilibili.com/bangumi/i/1699/",
+      "http://bangumi.bilibili.com/anime/1699",
       "http://www.iqiyi.com/a_19rrhbzeu5.html",
       "http://www.acfun.tv/v/ab1464808"
     ],
@@ -760,10 +684,10 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/fPpEVMRCTFc.html",
       "http://www.youku.com/show_page/id_z5d9421503e5011e4b2ad.html",
-      "http://www.bilibili.com/bangumi/i/301/",
-      "http://www.letv.com/comic/10005271.html",
+      "http://bangumi.bilibili.com/anime/301",
+      "http://www.le.com/comic/10005271.html",
       "http://www.iqiyi.com/a_19rrhbz5w5.html",
-      "http://www.pptv.com/page/296498.html",
+      "http://v.pptv.com/page/j6mDAWnPP33gXsY.html",
       "http://www.acfun.tv/a/aa1464823"
     ],
     "newBgm": true,
@@ -779,12 +703,11 @@
     "timeJP": "0040",
     "timeCN": "0140",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/317/",
-      "http://www.acfun.tv/a/aa1464825",
+      "http://bangumi.bilibili.com/anime/317",
       "http://www.tudou.com/albumcover/8kRmJfnSOqg.html",
       "http://www.youku.com/show_page/id_zdb2ab4f4066e11e4a705.html",
       "http://www.iqiyi.com/a_19rrhc0yyl.html",
-      "http://www.pptv.com/page/292431.html"
+      "http://v.pptv.com/page/wl46uCCG9jSXFX0.html"
     ],
     "newBgm": true,
     "bgmId": 96977,
@@ -802,9 +725,9 @@
       "http://www.tudou.com/albumcover/G_nSPK6V5b0.html",
       "http://www.youku.com/show_page/id_z358dbc7007e611e4a705.html",
       "http://www.iqiyi.com/a_19rrhc0yyx.html",
-      "http://www.pptv.com/page/295945.html",
-      "http://www.letv.com/comic/10005151.html",
-      "http://www.bilibili.com/bangumi/i/313/",
+      "http://v.pptv.com/page/ZL6aGIDmVpT3dd0.html",
+      "http://www.le.com/comic/10005151.html",
+      "http://bangumi.bilibili.com/anime/313",
       "http://www.acfun.tv/a/aa1464815"
     ],
     "newBgm": true,
@@ -820,10 +743,9 @@
     "timeJP": "1800",
     "timeCN": "1830",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/1569/",
+      "http://bangumi.bilibili.com/anime/1569",
       "http://www.iqiyi.com/a_19rrhc0zch.html",
       "http://www.youku.com/show_page/id_z3da69dee21c911e4a705.html",
-
       "http://www.acfun.tv/a/aa1464855"
     ],
     "newBgm": true,
@@ -839,12 +761,11 @@
     "timeJP": "2330",
     "timeCN": "0030",
     "onAirSite": [
-      "http://www.bilibili.com/bangumi/i/323/",
+      "http://bangumi.bilibili.com/anime/323",
       "http://www.tudou.com/albumcover/tQz-M8MDLYc.html",
       "http://www.youku.com/show_page/id_z8ea489d03d8611e4a080.html",
       "http://v.qq.com/detail/w/w9galx5d4dm0udo.html",
-      "http://www.iqiyi.com/a_19rrhbzby1.html",
-      "http://www.acfun.tv/a/aa1464842"
+      "http://www.iqiyi.com/a_19rrhbzby1.html"
     ],
     "newBgm": true,
     "bgmId": 67373,
@@ -859,12 +780,11 @@
     "timeJP": "2055",
     "timeCN": "",
     "onAirSite": [
-      "http://www.pptv.com/page/297831.html",
+      "http://v.pptv.com/page/Jf7aWMAmltQ3tR0.html",
       "http://www.youku.com/show_page/id_zcb776f203d6911e4b432.html",
       "http://www.tudou.com/albumcover/CYo3K-hgmOs.html",
       "http://v.qq.com/detail/1/1b4rfk13s84xu48.html",
-      "http://www.acfun.tv/a/aa1464853",
-      "http://www.bilibili.com/bangumi/i/1617/"
+      "http://bangumi.bilibili.com/anime/1617"
     ],
     "newBgm": true,
     "bgmId": 104878,
@@ -879,9 +799,8 @@
     "timeJP": "0000",
     "timeCN": "",
     "onAirSite": [
-      "http://www.acfun.tv/a/aa1464852",
-      "http://www.bilibili.com/bangumi/i/1530/",
-      "http://www.letv.com/comic/10005221.html",
+      "http://bangumi.bilibili.com/anime/1530",
+      "http://www.le.com/comic/10005221.html",
       "http://www.youku.com/show_page/id_zd3a9f5563d6d11e4b522.html",
       "http://www.tudou.com/albumcover/G4w3mr-huo0.html",
       "http://v.qq.com/detail/4/432204o0d8j3rnu.html"
@@ -899,8 +818,7 @@
     "timeJP": "2230",
     "timeCN": "2235",
     "onAirSite": [
-      "http://www.letv.com/comic/10001115.html",
-      "http://www.bilibili.com/sp/刀剑神域"
+      "http://www.le.com/comic/10001115.html"
     ],
     "newBgm": false,
     "bgmId": 92382,
@@ -916,8 +834,7 @@
     "timeCN": "2300",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgif3l1.html",
-      "http://www.acfun.tv/a/aa2649",
-      "http://www.bilibili.com/sp/白银的意志%20ARGEVOLLEN"
+      "http://www.acfun.tv/a/aa2649"
     ],
     "newBgm": false,
     "bgmId": 100498,
@@ -933,7 +850,6 @@
     "timeCN": "1030",
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgjao65.html",
-      "http://www.bilibili.com/sp/钻石王牌",
       "http://www.acfun.tv/v/ab1465812"
     ],
     "newBgm": false,
@@ -952,8 +868,7 @@
       "http://tv.sohu.com/s2014/qjbdssn2/",
       "http://www.youku.com/show_page/id_zb1e3a172f69311e3b2ad.html",
       "http://www.tudou.com/albumcover/vnUM26J8OqM.html",
-      "http://www.acfun.tv/a/aa2680",
-      "http://www.bilibili.com/sp/向山进发"
+      "http://www.acfun.tv/a/aa2680"
     ],
     "newBgm": false,
     "bgmId": 86670,
@@ -968,9 +883,7 @@
     "timeJP": "1800",
     "timeCN": "2000",
     "onAirSite": [
-      "http://tv.sohu.com/s2014/msnzsc/",
-      "http://www.bilibili.com/sp/美少女战士",
-      "http://www.acfun.tv/a/aa2659"
+      "http://tv.sohu.com/s2014/msnzsc/"
     ],
     "newBgm": true,
     "comment": "两周一话",
@@ -988,9 +901,8 @@
     "onAirSite": [
       "http://www.youku.com/show_page/id_z3b437b226dd211e38b3f.html",
       "http://www.tudou.com/albumcover/ypBszW6A2jk.html",
-      "http://www.letv.com/comic/95301.html",
-      "http://www.bilibili.com/bangumi/i/1711/",
-      "http://www.acfun.tv/a/aa254"
+      "http://www.le.com/comic/95301.html",
+      "http://bangumi.bilibili.com/anime/1711"
     ],
     "newBgm": false,
     "bgmId": 88348,
@@ -1008,10 +920,8 @@
       "http://v.qq.com/detail/o/o6ftuwm1j0xfa62.html",
       "http://www.tudou.com/albumcover/CIK0mT03n_M.html",
       "http://www.youku.com/show_page/id_zca5b9dc41c3f11e3b8b7.html",
-      "http://www.letv.com/comic/93548.html",
-      "http://www.bilibili.com/sp/宠物小精灵",
-      "http://www.acfun.tv/a/aa109_0",
-      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=宠物小精灵XY"
+      "http://www.le.com/comic/93548.html",
+      "http://www.tucao.cc/index.php?m=search&c=index&a=init2&q=%E5%AE%A0%E7%89%A9%E5%B0%8F%E7%B2%BE%E7%81%B5XY"
     ],
     "newBgm": false,
     "bgmId": 78799,
@@ -1026,11 +936,7 @@
     "timeJP": "1730",
     "timeCN": "",
     "onAirSite": [
-      "http://www.tudou.com/albumcover/vAUyu0OTz-M.html",
-      "http://www.youku.com/show_page/id_zab2d79f86dd011e3b8b7.html",
-      "http://v.qq.com/detail/h/hbccdwvo9t21w4i.html",
-      "http://www.bilibili.com/sp/妖怪手表",
-      "http://www.acfun.tv/a/aa220_0"
+      "http://v.qq.com/detail/h/hbccdwvo9t21w4i.html"
     ],
     "newBgm": false,
     "bgmId": 83124,
@@ -1044,11 +950,7 @@
     "weekDayCN": 3,
     "timeJP": "1730",
     "timeCN": "",
-    "onAirSite": [
-      "http://tv.sohu.com/s2014/majinbone/",
-      "http://www.bilibili.com/sp/魔神之骨",
-      "http://www.acfun.tv/a/aa1175"
-    ],
+    "onAirSite": [],
     "newBgm": false,
     "bgmId": 91135,
     "showDate": "2014-04-01"
@@ -1062,7 +964,6 @@
     "timeJP": "0800",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/展开骑士",
       "http://www.iqiyi.com/a_19rrhbz3g5.html"
     ],
     "newBgm": false,
@@ -1078,12 +979,9 @@
     "timeJP": "0900",
     "timeCN": "",
     "onAirSite": [
-      "http://www.letv.com/comic/10003003.html",
+      "http://www.le.com/comic/10003003.html",
       "http://www.youku.com/show_page/id_z94b79a0af68811e3b8b7.html",
-      "http://www.tudou.com/albumcover/CDmJERssqrQ.html",
-      "http://www.pptv.com/page/290583.html",
-      "http://www.acfun.tv/a/aa2658",
-      "http://www.bilibili.com/sp/美妙旋律%20彩虹之梦"
+      "http://www.tudou.com/albumcover/CDmJERssqrQ.html"
     ],
     "newBgm": false,
     "bgmId": 99748,
@@ -1101,7 +999,6 @@
       "http://www.iqiyi.com/a_19rrhc2yph.html",
       "http://www.youku.com/show_page/id_zdaf240e092e911e38b3f.html",
       "http://www.tudou.com/albumcover/8O6LrFIHhfc.html",
-      "http://www.bilibili.com/sp/复仇者联盟#S-889",
       "http://www.acfun.tv/a/aa1241"
     ],
     "newBgm": false,
@@ -1117,10 +1014,8 @@
     "timeJP": "0900",
     "timeCN": "",
     "onAirSite": [
-      "http://www.bilibili.com/sp/卡片战斗先导者",
       "http://www.youku.com/show_page/id_zdecc9d30adb711e38b3f.html",
-      "http://www.tudou.com/albumcover/idxgUQ7qnCA.html",
-      "http://www.acfun.tv/a/aa2297"
+      "http://www.tudou.com/albumcover/idxgUQ7qnCA.html"
     ],
     "newBgm": false,
     "bgmId": 90632,
@@ -1135,9 +1030,7 @@
     "timeJP": "0930",
     "timeCN": "1400",
     "onAirSite": [
-      "http://tv.sohu.com/s2011/yjdwb/",
-      "http://www.bilibili.com/sp/妖精的尾巴",
-      "http://www.acfun.tv/a/aa1214#group=1"
+      "http://tv.sohu.com/s2011/yjdwb/"
     ],
     "newBgm": false,
     "bgmId": 91946,
@@ -1154,7 +1047,6 @@
     "onAirSite": [
       "http://tv.sohu.com/s2014/lzg2",
       "http://www.iqiyi.com/a_19rrhb1cr1.html",
-      "http://www.bilibili.com/sp/龙珠#S-867",
       "http://www.acfun.tv/a/aa1243"
     ],
     "newBgm": false,
@@ -1172,8 +1064,8 @@
     "onAirSite": [
       "http://www.tudou.com/albumcover/95FqH0R7tO8.html",
       "http://www.youku.com/show_page/id_z61658ec6aa6311e3a705.html",
-      "http://www.letv.com/comic/10000910.html",
-      "http://www.pptv.com/page/286936.html",
+      "http://www.le.com/comic/10000910.html",
+      "http://v.pptv.com/page/VCWSEXnfT43wbtY.html",
       "http://www.bilibili.com/sp/宝石宠物#S-894",
       "http://www.acfun.tv/a/aa1263"
     ],
@@ -1192,10 +1084,8 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrgif6md.html",
       "http://tv.sohu.com/s2014/zchzt/",
-      "http://www.bilibili.com/bangumi/i/52/",
-      "http://www.acfun.tv/a/aa2667",
-      "http://www.youku.com/show_page/id_ze2cbdefaa75911e38b3f.html",
-      "http://www.tudou.com/albumcover/NBDgX_W2aJk.html"
+      "http://bangumi.bilibili.com/anime/52",
+      "http://www.acfun.tv/a/aa2667"
     ],
     "newBgm": false,
     "bgmId": 94244,
@@ -1212,8 +1102,7 @@
     "onAirSite": [
       "http://www.iqiyi.com/a_19rrhc1759.html",
       "http://tv.sohu.com/s2014/buddycomplex/",
-      "http://data.movie.kankan.com/movie/75159",
-      "http://www.acfun.tv/a/aa1464854"
+      "http://data.movie.kankan.com/movie/75159"
     ],
     "newBgm": true,
     "comment": "完结篇 共两话<br>前后篇即14-15话",


### PR DESCRIPTION
对 2014 年 10 月番全部进行了检查，检查方法：

1. 网页没有显示 404 或其它错误信息。
2. 网页上列出了（至少部分）剧集列表。（数个番组在优酷土豆上只有部分剧集，但仍保留）
3. 抽测剧集列表，能够播放。
4. Tucao.cc 链接，替换 tucao.cc 为 tucao.tv 进行测试。
5. Acfun 链接，替换 /aa*xxxx* 为 /ab*xxxx* 进行测试。
6. 部分 Acfun 链接，通过搜索番组标题进行测试。

部分链接进行了修改，主要为：

| 元 | 现 | 注 |
|:---|:--- |-----|
| bilibili.com/sp/*xxxx* | bangumi.bilibili.com/anime/*yyyy* | 人工替换 |
| bilibili.com/bangumi/i/*xxxx* | bangumi.bilibili.com/anime/*xxxx* | 302 跳转 |
| letv.com/comic/*xxxx*.html | le.com/comic/*xxxx*.html | 302 跳转 |
| pptv.com/page/*xxxx*.html | v.pptv.com/page/*yyyy*.html | 302 跳转 |